### PR TITLE
Add ANSI styling to program output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,6 +614,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,10 +834,12 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 name = "rust-rm"
 version = "0.1.0"
 dependencies = [
+ "anstream",
  "assert_cmd",
  "assert_fs",
  "clap",
  "log",
+ "owo-colors",
  "predicates",
  "proptest",
  "proptest-attr-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,10 @@ test-dangerous = []
 test-trash = []
 
 [dependencies]
+anstream = "0.3.1"
 clap = { version = "4.1.1", features = ["derive"] }
 log = "0.4.17"
+owo-colors = "3.5.0"
 trash = { version = "3.0.1", optional = true }
 
 [dev-dependencies]

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -157,27 +157,24 @@ pub(crate) use {has_exactly_lines, has_lines};
 /// ```
 pub mod rm_ask {
     pub fn descend<S: Into<String>>(subject: S) -> String {
-        format!("Descend into directory {}? [Y/n] {CLEARLINE}", subject.into())
+        format!("Descend into directory {}? [Y/n] ", subject.into())
     }
 
     pub fn dir<S: Into<String>>(subject: S) -> String {
-        format!("Remove directory {}? [Y/n] {CLEARLINE}", subject.into())
+        format!("Remove directory {}? [Y/n] ", subject.into())
     }
 
     pub fn empty_dir<S: Into<String>>(subject: S) -> String {
-        format!("Remove empty directory {}? [Y/n] {CLEARLINE}", subject.into())
+        format!("Remove empty directory {}? [Y/n] ", subject.into())
     }
 
     pub fn file<S: Into<String>>(subject: S) -> String {
-        format!("Remove regular file {}? [Y/n] {CLEARLINE}", subject.into())
+        format!("Remove regular file {}? [Y/n] ", subject.into())
     }
 
     pub fn link<S: Into<String>>(subject: S) -> String {
-        format!("Remove symbolic link {}? [Y/n] {CLEARLINE}", subject.into())
+        format!("Remove symbolic link {}? [Y/n] ", subject.into())
     }
-
-    /// String used to clear the current line on the terminal.
-    const CLEARLINE: &str = "\u{1b}[1A\u{1b}[2K";
 }
 
 /// Test helpers to generate strings outputted by the CLI.


### PR DESCRIPTION
Closes #5 

## Summary

Extend the use of ANSI styling from help messaging (generated by [`clap`]) to the program's own output. ANSI styling is implemented using [`anstream`] (also used by `clap`) and [`owo-colors`] (suggested in the documentation of `anstream`).

Following the suggestions of #5, this mainly highlights important information and dims optional output. In particular:

- Highlight what file/directory a message is about.
- Dim all tips.
- Dim all verbose messages.

[`clap`]: https://crates.io/crates/clap
[`anstream`]: https://crates.io/crates/anstream
[`owo-colors`]: https://crates.io/crates/owo-colors