### PR TITLE
Remove filled directories in one go with `--trash --recursive`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2424,7 +2424,7 @@ mod rm {
 
         #[test]
         #[cfg_attr(not(feature = "test-trash"), ignore = "Only run with the test-trash feature")]
-        fn dir_filled_toctou() -> TestResult {
+        fn dir_filled() -> TestResult {
             with_test_dir(|test_dir| {
                 let dir = test_dir.child("dir");
                 dir.create_dir_all()?;
@@ -2434,13 +2434,9 @@ mod rm {
                 let entry = fs::test_helpers::new_dir(path);
 
                 let out = dispose(entry);
-                assert!(out.is_err());
+                assert_eq!(out, Ok(format!("Moved {} to trash", path.display().bold())));
 
-                let err = out.expect_err("is_err() should be asserted");
-                assert_eq!(err.kind(), fs::ErrorKind::DirectoryNotEmpty);
-                assert_eq!(err.path(), path);
-
-                dir.assert(predicate::path::exists());
+                dir.assert(predicate::path::missing());
 
                 Ok(())
             })

--- a/tests/trash_test.rs
+++ b/tests/trash_test.rs
@@ -9,8 +9,6 @@ pub mod common;
 
 use crate::common::{has_exactly_lines, rm_out, TestResult};
 
-use std::path::MAIN_SEPARATOR;
-
 use assert_fs::prelude::*;
 use predicates::prelude::*;
 
@@ -126,10 +124,9 @@ fn filled_directory() -> TestResult {
             .assert()
             .success()
             .stdout(has_exactly_lines!(
-                rm_out::dry_trashed(format!("{dirname}{MAIN_SEPARATOR}{filename}")),
                 rm_out::dry_trashed(dirname);
                 rm_out::newline(),
-                rm_out::dry_conclusion(2, 0),
+                rm_out::dry_conclusion(1, 0),
             ))
             .stderr("");
         dir.assert(predicate::path::exists());
@@ -139,10 +136,9 @@ fn filled_directory() -> TestResult {
             .assert()
             .success()
             .stdout(has_exactly_lines!(
-                rm_out::trashed(format!("{dirname}{MAIN_SEPARATOR}{filename}")),
                 rm_out::trashed(dirname);
                 rm_out::newline(),
-                rm_out::conclusion(2, 0),
+                rm_out::conclusion(1, 0),
             ))
             .stderr("");
         dir.assert(predicate::path::missing());


### PR DESCRIPTION
Closes #4 

## Summary

Update `--trash --recursive` to remove filled directories in one go.