### PR TITLE
Use `macos-13` as MacOS runners in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-12
+            os: macos-13
           - name: Ubuntu
             os: ubuntu-22.04
           - name: Windows
@@ -67,7 +67,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-12
+            os: macos-13
           - name: Ubuntu
             os: ubuntu-22.04
           - name: Windows
@@ -262,7 +262,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-12
+            os: macos-13
           - name: Ubuntu
             os: ubuntu-22.04
           - name: Windows
@@ -302,7 +302,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-12
+            os: macos-13
           - name: Ubuntu
             os: ubuntu-22.04
           - name: Windows


### PR DESCRIPTION
## Summary

Update all continuous integration jobs that run on MacOS to use `macos-13` instead of `macos-12`. ~~As of this commit `macos-13` is still in beta. This Pull Request is intended to try out the new runner and see if it works for this project.~~ **EDIT:** As of Jan 30, 2024 `macos-13` is now generally available (and `macos-14` is in beta).

See also
- <https://github.blog/changelog/2023-04-24-github-actions-macos-13-is-now-available/>
- <https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/>