### PR TITLE
Proof of concept deletion of `fs::is_empty(&entry)` check when removing directories

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Check out rustup at: https://rust-lang.github.io/rustup/index.html
 
 [toolchain]
-channel = "1.69.0"
+channel = "nightly"
 components = [
     "cargo",
     "clippy",


### PR DESCRIPTION
Relates to #3

## Summary

Enable the `io_error_more` feature gate to get access to enum variant `io::ErrorKind::DirectoryNotEmpty` so that trying to remove a filled directory (due to a TOCTOU mismatch) fails correctly without the [custom emptiness check in the `rm::remove` function](https://github.com/ericcornelissen/rust-rm/blob/ef6e3a7185331ebb36663f880844641813a60e84/src/main.rs#L2616-L2622).

This is marked [`out_of_scope`](https://github.com/ericcornelissen/rust-rm/issues?q=label%3A%22out+of+scope%22) as I do not intend on merging a change requiring "+nightly" into the `main` branch.