### PR TITLE
Instruct Dependabot to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,12 @@ updates:
       time: "04:00"
     labels:
       - dependencies
+  - package-ecosystem: github-actions
+    directory: /
+    open-pull-requests-limit: 1
+    schedule:
+      interval: daily
+      time: "04:00"
+    labels:
+      - ci/cd
+      - dependencies


### PR DESCRIPTION
## Summary

Update the [Dependabot](https://github.com/dependabot) configuration to include the [`github-actions` ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem) so as to get the bot to [update GitHub Actions](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#github-actions).