### PR TITLE
Correct stated license & add documentation license

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ The development of this software is guided by the following principles:
 
 ## License
 
-This project is licensed under the Mozilla Public License 2.0 license, see [LICENSE] for the full
-license text.
+All source code is licensed under the Apache 2.0 license, see [LICENSE] for the full license text.
+The contents of documentation is licensed under [CC BY 4.0].
 
+[cc by 4.0]: https://creativecommons.org/licenses/by/4.0/
 [license]: ./LICENSE


### PR DESCRIPTION
## Summary

Update the README.md with a correction to the state license. It incorrectly stated this project is licensed under the MPL-2.0 license (this was a copy-paste error from one of my other projects) while linking to this project's Apache-2.0 license text. The README.md statement and LICENSE file (as well as source code SPDX license ids) are now aligned on Apache-2.0

Also add an explicit license for documentation content. A "permissive" creative commons variant (as opposed to the "copyleft" Share-Alike variant) is used in line with the permissive source code license.