### PR TITLE
Replace all usage of `static` by `const`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -761,10 +761,10 @@ mod cli {
 
     /// The environment variable name to enable compatibility mode with the `rm(1)` Unix command.
     #[cfg(feature = "classic")]
-    static CLASSIC_MODE: &str = "RUST_RM_CLASSIC";
+    const CLASSIC_MODE: &str = "RUST_RM_CLASSIC";
 
     /// A standard environment variable name to enable verbose mode.
-    static DEBUG_MODE: &str = "DEBUG";
+    const DEBUG_MODE: &str = "DEBUG";
 
     /// Struct representing parsed environment configuration values.
     #[cfg_attr(test, derive(Arbitrary, Clone, Copy, Debug))]
@@ -3824,7 +3824,7 @@ mod test_helpers {
     use assert_fs::TempDir;
 
     /// The environment variable name to enable debugging mode for tests.
-    static TEST_DEBUG_MODE: &str = "RUST_RM_DEBUG_TEST";
+    const TEST_DEBUG_MODE: &str = "RUST_RM_DEBUG_TEST";
 
     /// The `Result` type used by [`with_test_dir`].
     pub type TestResult = Result<(), Box<dyn std::error::Error>>;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -297,7 +297,7 @@ pub mod rm_out {
 }
 
 /// The environment variable name to enable debugging mode for tests.
-static TEST_DEBUG_MODE: &str = "RUST_RM_DEBUG_TEST";
+const TEST_DEBUG_MODE: &str = "RUST_RM_DEBUG_TEST";
 
 /// The `Result` type used by [`with_test_dir`].
 pub type TestResult = Result<(), Box<dyn std::error::Error>>;


### PR DESCRIPTION
## Summary

Refactor source and test code to exclusively use `const` following the [Rust By Example page on constants](https://doc.rust-lang.org/rust-by-example/custom_types/constants.html) and [Rust RFC 0246](https://github.com/rust-lang/rfcs/blob/39d1419/text/0246-const-vs-static.md). Per those resources, `const` is "the common case" whereas use of `static` should be rare. The project thus far used `const` and `static` interchangeably for similar purposes - this unifies the code base to the most sensible solution.

Just something I noticed while working on something else...
