### PR TITLE
Refactor transformation conditions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2938,6 +2938,7 @@ mod transform {
     use super::fs;
 
     use std::io;
+    use std::path::Path;
 
     use owo_colors::OwoColorize;
 
@@ -3026,11 +3027,16 @@ mod transform {
     /// Return all other values untouched.
     pub fn disallow_current_and_parent_dir(entry: fs::Result) -> fs::Result {
         match entry {
-            Ok(entry) if entry.path().ends_with(".") || entry.path().ends_with("..") => {
+            Ok(entry) if is_current_or_parent_dir(entry.path()) => {
                 Err(entry.into_err(fs::ErrorKind::Refused))
             },
             _ => entry,
         }
+    }
+
+    /// Check if the given [`Path`] is the current directory or parent directory.
+    fn is_current_or_parent_dir<P: AsRef<Path>>(path: P) -> bool {
+        path.as_ref().ends_with(".") || path.as_ref().ends_with("..")
     }
 
     /// Tests for the [`disallow_current_and_parent_dir`] function.
@@ -3182,11 +3188,14 @@ mod transform {
     /// untouched.
     pub fn disallow_root(entry: fs::Result) -> fs::Result {
         match entry {
-            Ok(entry) if entry.path().parent().is_none() => {
-                Err(entry.into_err(fs::ErrorKind::Refused))
-            },
+            Ok(entry) if is_root(entry.path()) => Err(entry.into_err(fs::ErrorKind::Refused)),
             _ => entry,
         }
+    }
+
+    /// Check if the given [`Path`] is the file system root.
+    fn is_root<P: AsRef<Path>>(path: P) -> bool {
+        path.as_ref().parent().is_none()
     }
 
     /// Tests for the [`disallow_root`] function.


### PR DESCRIPTION
Relates to #41

## Summary

Rewrite two of the [`mod transform`](https://github.com/ericcornelissen/rust-rm/blob/3d974d6ab880ca045a6689c1ba0427999bfd908a/src/main.rs#L2936-L3722) functions with non-trivial conditions by extracting the conditions into helper functions. While being a bit more verbose overall it both simplifies reading the transformer slightly (even if understanding the condition is fairly straightforward from context) and makes the transformer more robust to changes (especially in the case of `disallow_current_and_parent_dir` where duplication is reduced).