### PR TITLE
Bump Rust version from 1.69 to 1.70

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ To be able to contribute you need the following tooling:
 
 - [git] v2;
 - [Just] v1;
-- [Rust] and [Cargo] v1.69 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
+- [Rust] and [Cargo] v1.70 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.13.0 or later;
 - (Optional) [cargo-tarpaulin] v0.25.0 or later;

--- a/Justfile
+++ b/Justfile
@@ -181,6 +181,7 @@ _profile_prepare:
 		--deny clippy::dbg_macro \
 		--deny clippy::disallowed_script_idents \
 		--deny clippy::expect_used \
+		--deny clippy::let_underscore_untyped \
 		--deny clippy::if_then_some_else_none \
 		--deny clippy::impl_trait_in_params \
 		--deny clippy::indexing_slicing \

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ rm -fq file1 file2
 
 ## Build from Source
 
-To build from source you need [Rust] and [Cargo], v1.69 or higher, installed on your system. Then
+To build from source you need [Rust] and [Cargo], v1.70 or higher, installed on your system. Then
 run the command:
 
 ```shell

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Check out rustup at: https://rust-lang.github.io/rustup/index.html
 
 [toolchain]
-channel = "1.69.0"
+channel = "1.70.0"
 components = [
     "cargo",
     "clippy",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2614,7 +2614,7 @@ mod rm {
         trace!("remove {entry}");
 
         if entry.is_dir() && !fs::is_empty(&entry) {
-            // This case is handled explicitly because, as of Rust 1.69, the `io::ErrorKind` variant
+            // This case is handled explicitly because, as of Rust 1.70, the `io::ErrorKind` variant
             // is still experimental (gate "io_error_more") and so would result in an unknown error.
             // This implementation leaves a possibility for a TOCTOU issue, but this will be handled
             // safely as `std::fs::remove_dir` doesn't remove non-empty directories.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3038,7 +3038,7 @@ mod transform {
     mod test_disallow_current_and_parent_dir {
         use super::{disallow_current_and_parent_dir, fs};
 
-        use std::path::{Path, MAIN_SEPARATOR};
+        use std::path::{Path, MAIN_SEPARATOR_STR};
 
         use proptest::prelude::*;
         use proptest_attr_macro::proptest;
@@ -3055,7 +3055,7 @@ mod transform {
 
         #[proptest]
         fn entry_current_directory(path: CurrentDirPath) {
-            let path = path.0.replace('/', &MAIN_SEPARATOR.to_string());
+            let path = path.0.replace('/', MAIN_SEPARATOR_STR);
             let entry = fs::test_helpers::new_dir(&path);
 
             let out = disallow_current_and_parent_dir(Ok(entry));
@@ -3068,7 +3068,7 @@ mod transform {
 
         #[proptest]
         fn entry_parent_directory(path: ParentDirPath) {
-            let path = path.0.replace('/', &MAIN_SEPARATOR.to_string());
+            let path = path.0.replace('/', MAIN_SEPARATOR_STR);
             let entry = fs::test_helpers::new_dir(&path);
 
             let out = disallow_current_and_parent_dir(Ok(entry));


### PR DESCRIPTION
## Summary

Upgrade to the latest stable Rust release.

### Links

- [Rust 1.70.0 announcement](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
- [Clippy 1.70.0 changelog](https://github.com/rust-lang/rust-clippy/blob/c85ceeae3f1b61de9334b3abe427fa8312723239/CHANGELOG.md#rust-170)