### PR TITLE
Set up mutation testing with `cargo-mutants`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -129,7 +129,7 @@ jobs:
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: coverage-report
-          path: _reports/coverage-all.html
+          path: _reports/coverage/
   docs:
     name: Docs
     runs-on: ubuntu-22.04
@@ -176,6 +176,40 @@ jobs:
           tool: just@1
       - name: Check formatting
         run: just ci-fmt
+  mutation:
+    name: Mutation
+    runs-on: ubuntu-22.04
+    needs:
+      - test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
+      - name: Cache Rust & Cargo
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust toolchain
+        run: rustup show
+      - name: Install Just
+        uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3 # v2.9.0
+        with:
+          tool: just@1
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3 # v2.9.0
+        with:
+          tool: cargo-mutants@23.5.0
+      - name: Run mutation tests
+        run: just ci-mutation
+      - name: Upload mutation report
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: mutation-report
+          path: _reports/mutants.out/
   test:
     name: Test (${{ matrix.name }})
     runs-on: ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ this document.
     - [Test Organization](#test-organization)
     - [Types of Tests](#types-of-tests)
     - [Test Coverage](#test-coverage)
+    - [Mutation Testing](#mutation-testing)
     - [Special Tests](#special-tests)
   - [Documenting](#documenting)
   - [Vetting](#vetting)
@@ -107,6 +108,7 @@ To be able to contribute you need the following tooling:
 - [Rust] and [Cargo] v1.70 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.13.0 or later;
+- (Optional) [cargo-mutants] v23.0.0 or later;
 - (Optional) [cargo-tarpaulin] v0.25.0 or later;
 - (Suggested) a code editor with [EditorConfig] support;
 
@@ -119,6 +121,7 @@ To be able to contribute you need the following tooling:
 [rustfmt]: https://rust-lang.github.io/rustfmt/
 [cargo-all-features]: https://github.com/frewsxcv/cargo-all-features
 [cargo-deny]: https://github.com/EmbarkStudios/cargo-deny
+[cargo-mutants]: https://github.com/sourcefrog/cargo-mutants
 [cargo-tarpaulin]: https://github.com/xd009642/tarpaulin
 
 ### Workflow
@@ -281,13 +284,40 @@ commands:
 just coverage
 ```
 
-This will generate a coverage report in HTML format that can be found in the `_reports/` directory.
+This will generate a coverage report that can be found in the `_reports/coverage/` directory.
 
 If necessary you can configure the feature set to test using the `features` variable to adjust the
 build, for example:
 
 ```shell
 just features=classic coverage
+```
+
+#### Mutation Testing
+
+Mutation testing can be used as a guide to improve the test suite - if a mutation in the source code
+isn't detected by any test it indicates a gap in the suite. To aid in writing tests this project is
+set up with mutation testing powered by [cargo-mutants]. To generate a mutation report use the
+command:
+
+```shell
+just mutation
+```
+
+This will generate a mutation report in that can be found in the `_reports/mutants.out/` directory.
+
+You can configure the feature set to test using the `features` variable. This can be used to speed
+up mutation testing if you're only interested in a particular piece of functionality. For example:
+
+```shell
+just features=classic mutation
+```
+
+You may need to use the `test_features` variable to catch all mutants since some functionality has
+no or limited coverage without these. For example:
+
+```shell
+just test_features=test-trash mutation
 ```
 
 #### Special Tests

--- a/Justfile
+++ b/Justfile
@@ -105,6 +105,7 @@ alias v := vet
 		--output _reports/ \
 		--exclude-re cli::run \
 		--exclude-re logging \
+		--exclude-re 'impl Display' \
 		-- \
 		{{TEST_UNIT_ARGS}} \
 		{{TEST_FEATURES}}
@@ -234,7 +235,7 @@ _profile_prepare:
 [private]
 @ci-mutation:
 	just ci={{TRUE}} \
-		test_features=test-dangerous \
+		test_features=test-dangerous,test-trash \
 		mutation
 
 [private]

--- a/Justfile
+++ b/Justfile
@@ -50,7 +50,7 @@ alias v := vet
 		{{COVERAGE_ARGS}} \
 		{{TEST_FEATURES}} \
 		{{FEATURES}}
-	mv _reports/tarpaulin-report.html _reports/coverage-all.html
+	mv _reports/coverage/tarpaulin-report.html _reports/coverage/coverage-all.html
 
 # Produce a coverage report for integration tests
 @coverage-integration:
@@ -59,7 +59,7 @@ alias v := vet
 		{{TEST_INTEGRATION_ARGS}} \
 		{{TEST_FEATURES}} \
 		{{FEATURES}}
-	mv _reports/tarpaulin-report.html _reports/coverage-integration.html
+	mv _reports/coverage/tarpaulin-report.html _reports/coverage/coverage-integration.html
 
 # Produce a coverage report for unit tests
 @coverage-unit:
@@ -68,7 +68,7 @@ alias v := vet
 		{{TEST_UNIT_ARGS}} \
 		{{TEST_FEATURES}} \
 		{{FEATURES}}
-	mv _reports/tarpaulin-report.html _reports/coverage-unit.html
+	mv _reports/coverage/tarpaulin-report.html _reports/coverage/coverage-unit.html
 
 # Generate documentation for the project and dependencies
 @docs:
@@ -98,6 +98,16 @@ alias v := vet
 		-e '/^ *#!\[deny/d' \
 	> loc.rs
 	wc -l loc.rs
+
+# Run mutation tests
+@mutation:
+	cargo mutants \
+		--output _reports/ \
+		--exclude-re cli::run \
+		--exclude-re logging \
+		-- \
+		{{TEST_UNIT_ARGS}} \
+		{{TEST_FEATURES}}
 
 # Profile with visualization using <https://github.com/brendangregg/FlameGraph>
 [private]
@@ -222,6 +232,12 @@ _profile_prepare:
 	just ci={{TRUE}} fmt-check
 
 [private]
+@ci-mutation:
+	just ci={{TRUE}} \
+		test_features=test-dangerous \
+		mutation
+
+[private]
 @ci-test:
 	just ci={{TRUE}} \
 		test_features=test-dangerous,test-trash \
@@ -239,7 +255,7 @@ FALSE := "0"
 ci := FALSE
 
 STD_BUILD_ARGS := "--release"
-STD_COVERAGE_ARGS :=  "--count --line --engine llvm --out html --output-dir _reports"
+STD_COVERAGE_ARGS :=  "--count --line --engine llvm --out html --output-dir _reports/coverage/"
 STD_DOCS_ARGS := "--document-private-items"
 STD_TEST_ARGS := ""
 


### PR DESCRIPTION
Closes #7 

## Summary

Initialize [mutation testing](https://en.wikipedia.org/wiki/Mutation_testing) for this project using [cargo-mutants](https://github.com/sourcefrog/cargo-mutants) as mutation testing framework. The goal of using mutation testing is to improve the unit tests of this project and keep them good over time by making sure changes to the source code are properly tested.

The choice of mutation testing using only unit tests is primarily to ensure mutants are caught early and cheaply when they occur, whether by mutation testing or by changing the code. The integration tests for this project should be concerned with ensuring the CLI as a whole works as expected, not whether mutations are caught. That's not to say mutation testing can't help improve integration tests (e.g. through mutants in ignored functions), just that it's not the primary goal.