### PR TITLE
Bump cargo-deny from 0.13.8 to 0.13.9

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Install cargo-deny
         uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3 # v2.9.0
         with:
-          tool: cargo-deny@0.13.8
+          tool: cargo-deny@0.13.9
       - name: Audit
         run: just ci-audit

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -38,6 +38,6 @@ jobs:
       - name: Install cargo-deny
         uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3 # v2.9.0
         with:
-          tool: cargo-deny@0.13.8
+          tool: cargo-deny@0.13.9
       - name: Check compliance
         run: just ci-compliance


### PR DESCRIPTION
## Summary

Upgrade the version of [cargo-deny](https://crates.io/crates/cargo-deny) used in continuous integration workflows [from v0.13.8 to v0.13.9](https://github.com/EmbarkStudios/cargo-deny/compare/0.13.8...0.13.9).