### PR TITLE
Set up continuous coverage with Codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,22 @@
+# Check out Codecov at: https://codecov.io/
+
+coverage:
+  precision: 2
+  round: down
+  range: 80...100
+  status:
+    project:
+      default: false
+      source:
+        paths:
+          - src/
+
+comment:
+  layout: diff, files
+  behavior: once # "update, if exists. Otherwise post new. Skip if deleted."
+  require_changes: true # "only post the comment if coverage changes"
+  require_base: no
+  require_head: yes
+
+ignore:
+  - tests/**/*

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -124,12 +124,16 @@ jobs:
         with:
           tool: cargo-tarpaulin@0.25.2
       - name: Run all tests with coverage
-        run: just coverage
+        run: just ci-coverage
       - name: Upload coverage report
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: coverage-report
           path: _reports/coverage/
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+        with:
+          file: ./_reports/coverage/lcov.info
   docs:
     name: Docs
     runs-on: ubuntu-22.04

--- a/Justfile
+++ b/Justfile
@@ -225,6 +225,12 @@ _profile_prepare:
 	just ci={{TRUE}} compliance
 
 [private]
+@ci-coverage:
+	just ci={{TRUE}} \
+		test_features=test-dangerous,test-trash \
+		coverage
+
+[private]
 @ci-docs:
 	just ci={{TRUE}} docs
 
@@ -261,10 +267,11 @@ STD_DOCS_ARGS := "--document-private-items"
 STD_TEST_ARGS := ""
 
 CI_ONLY_CARGO_ARGS := if ci == TRUE { "--locked" } else { "" }
+CI_ONLY_COVERAGE_ARGS := if ci == TRUE { "--out lcov" } else { "" }
 CI_ONLY_TEST_ARGS := if ci == TRUE { "--no-fail-fast" } else { "" }
 
 BUILD_ARGS := STD_BUILD_ARGS + " " + CI_ONLY_CARGO_ARGS
-COVERAGE_ARGS := STD_COVERAGE_ARGS + " " + CI_ONLY_CARGO_ARGS
+COVERAGE_ARGS := STD_COVERAGE_ARGS + " " + CI_ONLY_CARGO_ARGS + " " + CI_ONLY_COVERAGE_ARGS
 DOCS_ARGS := STD_DOCS_ARGS + " " + CI_ONLY_CARGO_ARGS
 TEST_ARGS := STD_TEST_ARGS + " " + CI_ONLY_TEST_ARGS + " " + CI_ONLY_CARGO_ARGS
 TEST_INTEGRATION_ARGS := "--test '*'"


### PR DESCRIPTION
## Summary

Adjust the "Rust / Coverage" job to continuously upload coverage data to [Codecov] in order to gain insight over coverage over time.

[codecov]: https://codecov.io