### PR TITLE
Ignore potential items related to used tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ desktop.ini
 .idea/
 .vscode/
 
+## Mutation testing
+/mutants.out*/
+
 ## Profiling
 /profile_fs/
 /flamegraph.pl
@@ -22,3 +25,8 @@ desktop.ini
 /target/
 *.profraw
 **/*.rs.bk
+
+## Test coverage
+cobertura*
+lcov*
+tarpaulin*

--- a/Justfile
+++ b/Justfile
@@ -33,11 +33,15 @@ alias v := vet
 @_clean_git:
 	git clean -fx \
 		_reports/ \
+		mutants.out*/ \
 		profile_fs/ \
+		cobertura* \
+		lcov* \
 		loc.rs \
 		perf.data \
 		perf.data.old \
-		perf.svg
+		perf.svg \
+		tarpaulin*
 
 # Check license compliance
 @compliance:


### PR DESCRIPTION
## Summary

Update the `.gitignore` to include ignore directives for standard items that could be created by tooling if invoked without the `Justfile`. This is meant as a preventative measure to avoid these accidentally being commit when a contributor is testing with used tooling but, say, new configurations. Correspondingly update the `just clean` command.