### PR TITLE
Always enable `RUST_BACKTRACE` in continuous integration jobs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,6 +16,9 @@ on:
 
 permissions: read-all
 
+env:
+  RUST_BACKTRACE: 1
+
 jobs:
   cargo:
     name: Cargo

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -13,6 +13,9 @@ on:
 
 permissions: read-all
 
+env:
+  RUST_BACKTRACE: 1
+
 jobs:
   license:
     name: License

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,9 @@ on:
 
 permissions: read-all
 
+env:
+  RUST_BACKTRACE: 1
+
 jobs:
   build:
     name: Build (${{ matrix.name }})


### PR DESCRIPTION
## Summary

Update every CI workflow definition to always have the `RUST_BACKTRACE` environment variable enabled in order to have more verbose logging. More verbose logging should help understanding what went wrong just from the logs in more scenarios, thus making the continuous integration more useful.

It was decide to not enable this whenever using a `just ci-*` command as a contributor might (even if situationally) prefer to not have it enabled. Like with any other `just`command, we want to give contributors the choice to enable backtraces at their own convenience.