### PR TITLE
Rename classic mode to GNU mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ If your changes relate to a compile-time feature you can use the `features` vari
 build, for example:
 
 ```shell
-just features=classic build
+just features=gnu-mode build
 ```
 
 For greater certainty that your changes are valid you can also use the build command used in
@@ -198,7 +198,7 @@ If necessary you can configure the feature set to test with using the `features`
 the build, for example:
 
 ```shell
-just features=classic test
+just features=gnu-mode test
 ```
 
 For greater certainty that your changes are valid you can also use the test command used in
@@ -290,7 +290,7 @@ If necessary you can configure the feature set to test using the `features` vari
 build, for example:
 
 ```shell
-just features=classic coverage
+just features=gnu-mode coverage
 ```
 
 #### Mutation Testing
@@ -310,7 +310,7 @@ You can configure the feature set to test using the `features` variable. This ca
 up mutation testing if you're only interested in a particular piece of functionality. For example:
 
 ```shell
-just features=classic mutation
+just features=gnu-mode mutation
 ```
 
 You may need to use the `test_features` variable to catch all mutants since some functionality has
@@ -446,7 +446,7 @@ Add the following options to the `.vscode/settings.json` file for this project:
   // working on code related to one of these features.
   "rust-analyzer.cargo.noDefaultFeatures": true,
   "rust-analyzer.cargo.features": [
-    "classic",
+    "gnu-mode",
     "trash",
   ],
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ categories = ["development-tools", "filesystem"]
 edition = "2021"
 
 [features]
-default = ["classic", "trash"]
+default = ["gnu-mode", "trash"]
 
 ## Build features
-# Include support for the RUST_RM_CLASSIC environment variable
-classic = []
+# Include support for the RUST_RM_GNU_MODE environment variable
+gnu-mode = []
 # Include support for the --trash CLI option
 trash = ["dep:trash"]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `rust-rm`
 
-A CLI like the [`rm(1)`] Unix command but more modern and designed for humans. Aims to provide an
+A CLI like the [GNU version of `rm(1)`] but more modern and designed for humans. Aims to provide an
 `rm` command that feels familiar yet is safer and more user friendly. To this end it:
 
 - Defaults to a dry run, allowing for review before removing;
@@ -8,7 +8,7 @@ A CLI like the [`rm(1)`] Unix command but more modern and designed for humans. A
 - Supports moving to thrash, thanks to the [`trash` crate];
 - Offers an excellent CLI experience, thanks to the [`clap` crate];
 
-[`rm(1)`]: https://man7.org/linux/man-pages/man1/rm.1.html
+[gnu version of `rm(1)`]: https://man7.org/linux/man-pages/man1/rm.1.html
 [`clap` crate]: https://crates.io/crates/clap
 [`trash` crate]: https://crates.io/crates/trash
 
@@ -87,13 +87,13 @@ just features=[FEATURES] build
 
 where `[FEATURES]` is one or more of:
 
-- `classic`: to include support for the [classic mode](#classic-mode).
+- `gnu-mode`: to include support for the [GNU mode](#gnu-mode).
 - `trash`: to include support for the `--trash` option.
 
 For example:
 
 ```shell
-just features=classic,trash build
+just features=gnu-mode,trash build
 ```
 
 Or, to omit all optional features:
@@ -102,15 +102,15 @@ Or, to omit all optional features:
 just features= build
 ```
 
-## Classic Mode
+## GNU Mode
 
-The environment variable `RUST_RM_CLASSIC` can be used to enable _classic mode_. This mode aims to
-offer some opt-in backwards compatibility with Unix `rm(1)`. It's meant to be useful for scripts. As
-such, it aims to be compatible with non-failing and semantically valid use cases.
+The environment variable `RUST_RM_GNU_MODE` can be used to enable _GNU mode_. This mode aims to
+offer some opt-in backwards compatibility with the GNU version of `rm(1)`. It's meant to be useful
+for scripts. As such, it aims to be compatible with non-failing and semantically valid use cases.
 
-> **Note**: Classic mode is only available if the `classic` feature was enabled at compile time.
+> **Note**: GNU mode is only available if the `gnu-mode` feature was enabled at compile time.
 
-Classic mode will cause `rm` to:
+GNU mode mode will cause `rm` to:
 
 - Remove (unlink) files and directories without `--force` or `--interactive`.
 - Behave `--blind` when `--force` is used (and forget the `--blind` flag).
@@ -119,7 +119,7 @@ Classic mode will cause `rm` to:
 
 It won't cause `rm` to:
 
-- Have the same `stdout`/`stderr`/`stdin` as `rm(1)`.
+- Change its `stdout`/`stderr`/`stdin`.
 - Support the `-R` flag.
 - Support the `-I` or `--interactive=WHEN` flags.
 

--- a/tests/gnu_mode_test.rs
+++ b/tests/gnu_mode_test.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-//! Test suite focussed on testing the functionality of classic mode.
+//! Test suite focussed on testing the functionality of GNU mode.
 
 pub mod common;
 
@@ -10,7 +10,7 @@ use assert_fs::prelude::*;
 use predicates::prelude::*;
 
 #[test]
-#[cfg(feature = "classic")]
+#[cfg(feature = "gnu-mode")]
 fn remove_file() -> TestResult {
     let filename = "file";
 
@@ -26,7 +26,7 @@ fn remove_file() -> TestResult {
 }
 
 #[test]
-#[cfg(feature = "classic")]
+#[cfg(feature = "gnu-mode")]
 fn remove_empty_dir() -> TestResult {
     let dirname = "dir";
 
@@ -45,7 +45,7 @@ fn remove_empty_dir() -> TestResult {
 }
 
 #[test]
-#[cfg(feature = "classic")]
+#[cfg(feature = "gnu-mode")]
 fn remove_empty_dir_recursively() -> TestResult {
     let dirname = "dir";
 
@@ -64,7 +64,7 @@ fn remove_empty_dir_recursively() -> TestResult {
 }
 
 #[test]
-#[cfg(feature = "classic")]
+#[cfg(feature = "gnu-mode")]
 fn remove_filled_dir_recursively() -> TestResult {
     let dirname = "dir";
 
@@ -86,7 +86,7 @@ fn remove_filled_dir_recursively() -> TestResult {
 }
 
 #[test]
-#[cfg(feature = "classic")]
+#[cfg(feature = "gnu-mode")]
 fn remove_symlink() -> TestResult {
     let linkname = "link";
 
@@ -105,7 +105,7 @@ fn remove_symlink() -> TestResult {
 }
 
 #[test]
-#[cfg(feature = "classic")]
+#[cfg(feature = "gnu-mode")]
 fn remove_missing() -> TestResult {
     let filename = "file";
 
@@ -117,7 +117,7 @@ fn remove_missing() -> TestResult {
 }
 
 #[test]
-#[cfg(feature = "classic")]
+#[cfg(feature = "gnu-mode")]
 fn remove_missing_with_force() -> TestResult {
     with_test_dir(|mut cmd, _test_dir| {
         cmd.args(["--force", "file"]).assert().success();
@@ -127,7 +127,7 @@ fn remove_missing_with_force() -> TestResult {
 }
 
 #[test]
-#[cfg(feature = "classic")]
+#[cfg(feature = "gnu-mode")]
 fn stdout_and_stderr_on_success() -> TestResult {
     let filename = "file";
 
@@ -142,7 +142,7 @@ fn stdout_and_stderr_on_success() -> TestResult {
 }
 
 #[test]
-#[cfg(feature = "classic")]
+#[cfg(feature = "gnu-mode")]
 fn interactive_no() -> TestResult {
     let filename = "file";
 
@@ -163,7 +163,7 @@ fn interactive_no() -> TestResult {
 }
 
 #[test]
-#[cfg(feature = "classic")]
+#[cfg(feature = "gnu-mode")]
 fn interactive_yes() -> TestResult {
     let filename = "file";
 
@@ -184,7 +184,7 @@ fn interactive_yes() -> TestResult {
 }
 
 #[test]
-#[cfg(feature = "classic")]
+#[cfg(feature = "gnu-mode")]
 fn invalid_flag_blind() -> TestResult {
     unsupported_flag("--blind")?;
     unsupported_flag_with_force("--blind")?;
@@ -193,7 +193,7 @@ fn invalid_flag_blind() -> TestResult {
 }
 
 #[test]
-#[cfg(feature = "classic")]
+#[cfg(feature = "gnu-mode")]
 fn invalid_flag_quiet() -> TestResult {
     unsupported_flag("--quiet")?;
     unsupported_flag_with_force("--quiet")?;
@@ -202,7 +202,7 @@ fn invalid_flag_quiet() -> TestResult {
 }
 
 #[test]
-#[cfg(all(feature = "classic", feature = "trash"))]
+#[cfg(all(feature = "gnu-mode", feature = "trash"))]
 fn invalid_flag_trash() -> TestResult {
     unsupported_flag("--trash")?;
     unsupported_flag_with_force("--trash")?;
@@ -211,8 +211,8 @@ fn invalid_flag_trash() -> TestResult {
 }
 
 #[test]
-#[cfg(not(feature = "classic"))]
-fn classic_mode_ignored_without_the_build_feature() -> TestResult {
+#[cfg(not(feature = "gnu-mode"))]
+fn ignored_without_the_build_feature() -> TestResult {
     let filename = "file";
 
     with_test_dir(|mut cmd, test_dir| {
@@ -229,34 +229,34 @@ fn classic_mode_ignored_without_the_build_feature() -> TestResult {
     })
 }
 
-/// Test the behavior of using an unsupported flag in classic mode (without `--force`).
+/// Test the behavior of using an unsupported flag in GNU mode (without `--force`).
 ///
 /// # Example
 ///
 /// ```no_run
 /// unsupported_flag("--flag");
 /// ```
-#[cfg(feature = "classic")]
+#[cfg(feature = "gnu-mode")]
 fn unsupported_flag(flag: &str) -> TestResult {
     with_test_dir(|mut cmd, _test_dir| {
         cmd.arg(flag)
             .assert()
             .failure()
             .stdout("")
-            .stderr(format!("error: option {flag} not supported in classic mode\n"));
+            .stderr(format!("error: option {flag} not supported in GNU mode\n"));
 
         Ok(())
     })
 }
 
-/// Test the behavior of using an unsupported flag in classic mode with `--force`.
+/// Test the behavior of using an unsupported flag in GNU mode with `--force`.
 ///
 /// # Example
 ///
 /// ```no_run
 /// unsupported_flag_with_force("--flag");
 /// ```
-#[cfg(feature = "classic")]
+#[cfg(feature = "gnu-mode")]
 fn unsupported_flag_with_force(flag: &str) -> TestResult {
     with_test_dir(|mut cmd, _test_dir| {
         cmd.args(["--force", flag]).assert().success();
@@ -265,7 +265,7 @@ fn unsupported_flag_with_force(flag: &str) -> TestResult {
     })
 }
 
-/// Run a test with classic mode enabled.
+/// Run a test with GNU mode enabled.
 ///
 /// See also [`common::with_test_dir`].
 fn with_test_dir<C>(callback: C) -> TestResult
@@ -273,7 +273,7 @@ where
     C: FnOnce(assert_cmd::Command, &assert_fs::TempDir) -> TestResult,
 {
     common::with_test_dir(|mut cmd, test_dir| {
-        cmd.env("RUST_RM_CLASSIC", "1");
+        cmd.env("RUST_RM_GNU_MODE", "1");
         callback(cmd, test_dir)
     })
 }


### PR DESCRIPTION
Closes #35

## Summary

Change the name of the mode that emulates the ~~Unix~~ GNU version of `rm(1)` from classic mode (RUST_RM_CLASSIC) to GNU mode (RUST_RM_GNU_MODE) in order to 1) make it easier to guess the behavior when the environment variable is set, and 2) make it explicit what behavior will be emulated.

Note that, prior to this change, per the first change in the README.md, it was understood that classic mode emulated the "Unix" implementation of `rm(1)`. This is not the case (and I don't think a  "Unix version" of `rm(1)` actually exists), instead it emulates the [GNU version of rm](https://man7.org/linux/man-pages/man1/rm.1.html). As such, the new name was chosen per the above reasoning.

### Post-merge

- [ ] Update the repository description.