### PR TITLE
Fix removal of symbolic links on Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -350,6 +350,30 @@ To run dangerous tests use the command:
 just test_features=test-dangerous test
 ```
 
+##### Symlink Tests
+
+Some tests work with symbolic links (symlinks). Working with symlinks on Windows requires elevated
+permissions, so these tests aren't run by default on Windows to avoid unexpected errors.
+
+The following configuration must be used on all tests that (potentially) create symbolic links:
+
+```rust
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
+```
+
+To run tests involving symbolic links on Windows ensure you have elevated privileges and use the
+command:
+
+```shell
+just test_features=test-symlink test
+```
+
+> **Note**: On non-Windows systems tests involving symlinks are run by default (regardless of the
+> `test-symlink` feature).
+
 ### Documenting
 
 This project is extensively documented. All source code should be documented to aid reuse without

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ trash = ["dep:trash"]
 ## Test-only features
 # Used for running dangerous tests conditionally.
 test-dangerous = []
+# Used for running tests involving symbolic links conditionally (Windows only).
+test-symlink = []
 # Used for running test that move things to the trash conditionally.
 test-trash = []
 
@@ -50,4 +52,4 @@ panic = "abort"
 strip = "debuginfo"
 
 [package.metadata.cargo-all-features]
-denylist = ["test-dangerous", "test-trash"]
+denylist = ["test-dangerous", "test-symlink", "test-trash"]

--- a/Justfile
+++ b/Justfile
@@ -231,7 +231,7 @@ _profile_prepare:
 [private]
 @ci-coverage:
 	just ci={{TRUE}} \
-		test_features=test-dangerous,test-trash \
+		test_features=test-dangerous,test-symlink,test-trash \
 		coverage
 
 [private]
@@ -245,13 +245,13 @@ _profile_prepare:
 [private]
 @ci-mutation:
 	just ci={{TRUE}} \
-		test_features=test-dangerous,test-trash \
+		test_features=test-dangerous,test-symlink,test-trash \
 		mutation
 
 [private]
 @ci-test:
 	just ci={{TRUE}} \
-		test_features=test-dangerous,test-trash \
+		test_features=test-dangerous,test-symlink,test-trash \
 		test-each
 
 [private]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1258,6 +1258,10 @@ mod fs {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink() -> TestResult {
             with_test_dir(|test_dir| {
                 let file = test_dir.child("file");
@@ -1393,6 +1397,10 @@ mod fs {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink_to_empty_file() -> TestResult {
             with_test_dir(|test_dir| {
                 let file = test_dir.child("file");
@@ -1410,6 +1418,10 @@ mod fs {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink_to_filled_file() -> TestResult {
             with_test_dir(|test_dir| {
                 let file = test_dir.child("file");
@@ -1427,6 +1439,10 @@ mod fs {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink_to_empty_dir() -> TestResult {
             with_test_dir(|test_dir| {
                 let dir = test_dir.child("dir");
@@ -1444,6 +1460,10 @@ mod fs {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink_to_filled_dir() -> TestResult {
             with_test_dir(|test_dir| {
                 let dir = test_dir.child("dir");
@@ -2000,6 +2020,10 @@ mod walk {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink_to_file() -> TestResult {
             with_test_dir(|test_dir| {
                 let file = test_dir.child("file");
@@ -2017,6 +2041,10 @@ mod walk {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink_to_empty_dir() -> TestResult {
             with_test_dir(|test_dir| {
                 let dir = test_dir.child("dir");
@@ -2034,6 +2062,10 @@ mod walk {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink_to_filled_dir() -> TestResult {
             with_test_dir(|test_dir| {
                 let dir = test_dir.child("dir");
@@ -2207,6 +2239,10 @@ mod walk {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink_to_file() -> TestResult {
             with_test_dir(|test_dir| {
                 let file = test_dir.child("file");
@@ -2224,6 +2260,10 @@ mod walk {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink_to_empty_dir() -> TestResult {
             with_test_dir(|test_dir| {
                 let dir = test_dir.child("dir");
@@ -2241,6 +2281,10 @@ mod walk {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink_to_filled_dir() -> TestResult {
             with_test_dir(|test_dir| {
                 let dir = test_dir.child("dir");
@@ -2524,7 +2568,10 @@ mod rm {
         }
 
         #[test]
-        #[cfg_attr(not(feature = "test-trash"), ignore = "Only run with the test-trash feature")]
+        #[cfg_attr(
+            any(not(feature = "test-trash"), all(windows, not(feature = "test-symlink"))),
+            ignore = "Only run with the test-trash (and test-symlink on Windows) feature"
+        )]
         fn symlink_to_file() -> TestResult {
             with_test_dir(|test_dir| {
                 let file = test_dir.child("file");
@@ -2546,7 +2593,10 @@ mod rm {
         }
 
         #[test]
-        #[cfg_attr(not(feature = "test-trash"), ignore = "Only run with the test-trash feature")]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink_to_empty_dir() -> TestResult {
             with_test_dir(|test_dir| {
                 let dir = test_dir.child("dir");
@@ -2617,7 +2667,10 @@ mod rm {
         }
 
         #[test]
-        #[cfg_attr(not(feature = "test-trash"), ignore = "Only run with the test-trash feature")]
+        #[cfg_attr(
+            any(not(feature = "test-trash"), all(windows, not(feature = "test-symlink"))),
+            ignore = "Only run with the test-trash (and test-symlink on Windows) feature"
+        )]
         fn symlink_to_file_at_location_of_a_file_toctou() -> TestResult {
             with_test_dir(|test_dir| {
                 let file = test_dir.child("file");
@@ -2639,7 +2692,10 @@ mod rm {
         }
 
         #[test]
-        #[cfg_attr(not(feature = "test-trash"), ignore = "Only run with the test-trash feature")]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink_to_dir_at_location_of_a_dir_toctou() -> TestResult {
             with_test_dir(|test_dir| {
                 let dir = test_dir.child("dir");
@@ -2800,6 +2856,10 @@ mod rm {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink_to_file() -> TestResult {
             with_test_dir(|test_dir| {
                 let file = test_dir.child("file");
@@ -2887,6 +2947,10 @@ mod rm {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn symlink_to_file_at_location_of_a_file_toctou() -> TestResult {
             with_test_dir(|test_dir| {
                 let file = test_dir.child("file");
@@ -3279,7 +3343,7 @@ mod transform {
         use proptest_attr_macro::proptest;
 
         #[proptest]
-        #[cfg_attr(windows, ignore = "TODO: investigate symlink test errors on Windows")]
+        #[cfg_attr(windows, ignore = "TODO: investigate errors on Windows")]
         fn non_root(item: walk::Item) {
             if let Ok(entry) = item.inner.as_ref() {
                 prop_assume!(entry.path() != Path::new("/"));
@@ -3586,6 +3650,10 @@ mod transform {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn new_prompt_for_symlink_to_file() -> TestResult {
             with_test_dir(|test_dir| {
                 let file = test_dir.child("file");
@@ -3607,6 +3675,10 @@ mod transform {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn new_prompt_for_symlink_to_empty_dir() -> TestResult {
             with_test_dir(|test_dir| {
                 let dir = test_dir.child("dir");
@@ -3628,6 +3700,10 @@ mod transform {
         }
 
         #[test]
+        #[cfg_attr(
+            all(windows, not(feature = "test-symlink")),
+            ignore = "Only run with the test-symlink feature"
+        )]
         fn new_prompt_for_symlink_to_filled_dir() -> TestResult {
             with_test_dir(|test_dir| {
                 let dir = test_dir.child("dir");

--- a/tests/dir_test.rs
+++ b/tests/dir_test.rs
@@ -147,7 +147,10 @@ fn symlink_to_file() -> TestResult {
 }
 
 #[test]
-#[cfg_attr(windows, ignore = "TODO: investigate symlink test errors on Windows")]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn symlink_to_empty_dir() -> TestResult {
     let linkname = "link";
 
@@ -186,7 +189,10 @@ fn symlink_to_empty_dir() -> TestResult {
 }
 
 #[test]
-#[cfg_attr(windows, ignore = "TODO: investigate symlink test errors on Windows")]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn symlink_to_filled_dir() -> TestResult {
     let linkname = "link";
 

--- a/tests/dir_test.rs
+++ b/tests/dir_test.rs
@@ -105,6 +105,10 @@ fn filled_dir() -> TestResult {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn symlink_to_file() -> TestResult {
     let linkname = "link";
 

--- a/tests/gnu_mode_test.rs
+++ b/tests/gnu_mode_test.rs
@@ -87,6 +87,10 @@ fn remove_filled_dir_recursively() -> TestResult {
 
 #[test]
 #[cfg(feature = "gnu-mode")]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn remove_symlink() -> TestResult {
     let linkname = "link";
 

--- a/tests/interactive_test.rs
+++ b/tests/interactive_test.rs
@@ -44,6 +44,10 @@ fn remove_file_no() -> TestResult {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn remove_symlink_no() -> TestResult {
     let linkname = "link";
 
@@ -201,6 +205,10 @@ fn remove_file_yes() -> TestResult {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn remove_symlink_yes() -> TestResult {
     let linkname = "link";
 

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -12,6 +12,10 @@ use assert_fs::prelude::*;
 use predicates::prelude::*;
 
 #[test]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn symlink_to_a_file_remove_link() -> TestResult {
     let linkname = "link";
 
@@ -50,6 +54,10 @@ fn symlink_to_a_file_remove_link() -> TestResult {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn symlink_to_a_file_remove_file() -> TestResult {
     let filename = "linked_file";
     let linkname = "link";
@@ -127,6 +135,10 @@ fn symlink_to_an_empty_dir_remove_link() -> TestResult {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn symlink_to_an_empty_dir_remove_dir() -> TestResult {
     let dirname = "linked_dir";
     let linkname = "link";

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -96,7 +96,10 @@ fn symlink_to_a_file_remove_file() -> TestResult {
 }
 
 #[test]
-#[cfg_attr(windows, ignore = "TODO: investigate symlink test errors on Windows")]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn symlink_to_an_empty_dir_remove_link() -> TestResult {
     let linkname = "link";
 
@@ -177,7 +180,10 @@ fn symlink_to_an_empty_dir_remove_dir() -> TestResult {
 }
 
 #[test]
-#[cfg_attr(windows, ignore = "TODO: investigate symlink test errors on Windows")]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn symlink_to_a_filled_dir_remove_link() -> TestResult {
     let linkname = "link";
 

--- a/tests/quiet_test.rs
+++ b/tests/quiet_test.rs
@@ -38,6 +38,10 @@ fn file() -> TestResult {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn symlink() -> TestResult {
     let linkname = "link";
 

--- a/tests/recursive_test.rs
+++ b/tests/recursive_test.rs
@@ -172,6 +172,10 @@ fn nested_dir() -> TestResult {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn symlink_to_file() -> TestResult {
     let linkname = "link";
 

--- a/tests/recursive_test.rs
+++ b/tests/recursive_test.rs
@@ -214,7 +214,10 @@ fn symlink_to_file() -> TestResult {
 }
 
 #[test]
-#[cfg_attr(windows, ignore = "TODO: investigate symlink test errors on Windows")]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn symlink_to_empty_dir() -> TestResult {
     let linkname = "link";
 
@@ -253,7 +256,10 @@ fn symlink_to_empty_dir() -> TestResult {
 }
 
 #[test]
-#[cfg_attr(windows, ignore = "TODO: investigate symlink test errors on Windows")]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn symlink_to_filled_dir() -> TestResult {
     let linkname = "link";
 

--- a/tests/trash_test.rs
+++ b/tests/trash_test.rs
@@ -149,7 +149,10 @@ fn filled_directory() -> TestResult {
 
 #[test]
 #[cfg(feature = "trash")]
-#[cfg_attr(not(feature = "test-trash"), ignore = "Only run with the test-trash feature")]
+#[cfg_attr(
+    any(not(feature = "test-trash"), all(windows, not(feature = "test-symlink"))),
+    ignore = "Only run with the test-trash (and test-symlink on Windows) feature"
+)]
 fn link() -> TestResult {
     let linkname = "link";
 

--- a/tests/verbose_test.rs
+++ b/tests/verbose_test.rs
@@ -26,6 +26,10 @@ fn nothing_to_do() -> TestResult {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, not(feature = "test-symlink")),
+    ignore = "Only run with the test-symlink feature"
+)]
 fn found_file_dir_and_link() -> TestResult {
     let filename = "file";
     let dirname = "dir";


### PR DESCRIPTION
Closes #1 

## Summary

Update how symlinks on Windows are removed as well as how it is tested.

Tests involving symlinks are now run conditionally on the (new) `test-symlink` feature on Windows in order to avoid unexpected test failures due to the elevated privileges requirement for working with symlinks on Windows.

The implementation for removing symlinks is updated such that, on Windows, removing a symlink of a directory uses [`std::fs::remove_dir`](https://doc.rust-lang.org/std/fs/fn.remove_dir.html). This appears to be necessary for removing symbolic links of directories, while using [`std::fs::remove_file`](https://doc.rust-lang.org/std/fs/fn.remove_file.html) is appears to be necessary for removing symbolic links of files.