### PR TITLE
Bump Rust toolchain channel from 1.70 to 1.71

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ To be able to contribute you need the following tooling:
 
 - [git] v2;
 - [Just] v1;
-- [Rust] and [Cargo] v1.70 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
+- [Rust] and [Cargo] v1.71 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.13.0 or later;
 - (Optional) [cargo-mutants] v23.0.0 or later;

--- a/Justfile
+++ b/Justfile
@@ -206,6 +206,7 @@ _profile_prepare:
 		--deny clippy::print_stdout \
 		--deny clippy::rc_buffer \
 		--deny clippy::rc_mutex \
+		--deny clippy::ref_patterns \
 		--deny clippy::unwrap_used
 
 @_vet_verify_project:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ rm -fq file1 file2
 
 ## Build from Source
 
-To build from source you need [Rust] and [Cargo], v1.70 or higher, installed on your system. Then
+To build from source you need [Rust] and [Cargo], v1.71 or higher, installed on your system. Then
 run the command:
 
 ```shell

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Check out rustup at: https://rust-lang.github.io/rustup/index.html
 
 [toolchain]
-channel = "1.70.0"
+channel = "1.71.0"
 components = [
     "cargo",
     "clippy",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2728,7 +2728,7 @@ mod rm {
         trace!("remove {entry}");
 
         if entry.is_dir() && !fs::is_empty(&entry) {
-            // This case is handled explicitly because, as of Rust 1.70, the `io::ErrorKind` variant
+            // This case is handled explicitly because, as of Rust 1.71, the `io::ErrorKind` variant
             // is still experimental (gate "io_error_more") and so would result in an unknown error.
             // This implementation leaves a possibility for a TOCTOU issue, but this will be handled
             // safely as `std::fs::remove_dir` doesn't remove non-empty directories.


### PR DESCRIPTION
Relates to #46

## Summary

Upgrade the version of Rust and related tooling from 1.70.0 to the latest stable version 1.71.0.

## References

- [Rust 1.71 announcement](https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html)
- [Clippy 1.71 changelog](https://github.com/rust-lang/rust-clippy/blob/bafde54367964e9337e6a88743ad6f0299ee8c75/CHANGELOG.md#rust-171)