### PR TITLE
Bump `cargo-mutants` and `cargo-tarpaulin` to latest

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Install cargo-tarpaulin
         uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3 # v2.9.0
         with:
-          tool: cargo-tarpaulin@0.25.2
+          tool: cargo-tarpaulin@0.26.1
       - name: Run all tests with coverage
         run: just ci-coverage
       - name: Upload coverage report
@@ -211,7 +211,7 @@ jobs:
       - name: Install cargo-mutants
         uses: taiki-e/install-action@1d74f337f279f52e54c352ebe5b96eaa36c948d3 # v2.9.0
         with:
-          tool: cargo-mutants@23.5.0
+          tool: cargo-mutants@23.6.0
       - name: Run mutation tests
         run: just ci-mutation
       - name: Upload mutation report


### PR DESCRIPTION
Relates to #51, #52

## Summary

Update all cargo tooling (listed in the prerequisites section of the Contributing Guidelines) to the latest version. `cargo-all-features` and `cargo-deny` don't have a new version available. `cargo-mutants` bumped from [23.5.0 to 23.6.0](https://github.com/sourcefrog/cargo-mutants/compare/cargo-mutants-23.5.0...cargo-mutants-23.6.0) with a myriad of improvements. `cargo-tarpaulin` bumped from [0.25.2 to 0.26.1](https://github.com/xd009642/tarpaulin/compare/0.25.2...0.26.1) with some fixes and improvements.
