### PR TITLE
Bump Rust toolchain channel from 1.71 to 1.72

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ To be able to contribute you need the following tooling:
 
 - [git] v2;
 - [Just] v1;
-- [Rust] and [Cargo] v1.71 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
+- [Rust] and [Cargo] v1.72 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.13.0 or later;
 - (Optional) [cargo-mutants] v23.0.0 or later;

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ rm -fq file1 file2
 
 ## Build from Source
 
-To build from source you need [Rust] and [Cargo], v1.71 or higher, installed on your system. Then
+To build from source you need [Rust] and [Cargo], v1.72 or higher, installed on your system. Then
 run the command:
 
 ```shell

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Check out rustup at: https://rust-lang.github.io/rustup/index.html
 
 [toolchain]
-channel = "1.71.0"
+channel = "1.72.0"
 components = [
     "cargo",
     "clippy",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2728,7 +2728,7 @@ mod rm {
         trace!("remove {entry}");
 
         if entry.is_dir() && !fs::is_empty(&entry) {
-            // This case is handled explicitly because, as of Rust 1.71, the `io::ErrorKind` variant
+            // This case is handled explicitly because, as of Rust 1.72, the `io::ErrorKind` variant
             // is still experimental (gate "io_error_more") and so would result in an unknown error.
             // This implementation leaves a possibility for a TOCTOU issue, but this will be handled
             // safely as `std::fs::remove_dir` doesn't remove non-empty directories.

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -63,13 +63,13 @@ macro_rules! has_exactly_lines {
         $( .and(predicates::str::contains($line)) )*
         // ... and has the same length as all strings taken together ...
         .and(predicates::function::function(|s: &str| {
-            s.len() == vec![$( $line, )*].join("").len()
+            s.len() == [$( $line, )*].join("").len()
         }))
         // ... means it only has these lines.
     };
     ($($line:expr),* ; $($last_line:expr),* $(,)?) => {
         has_exactly_lines!($( $line, )* $( $last_line, )*).and(
-            predicates::str::ends_with(vec![$( $last_line, )*].join(""))
+            predicates::str::ends_with([$( $last_line, )*].join(""))
         )
     };
 }
@@ -132,7 +132,7 @@ macro_rules! has_lines {
     };
     ($($line:expr),* ; $($last_line:expr),* $(,)?) => {
         has_lines!($( $line, )* $( $last_line, )*).and(
-            predicates::str::ends_with(vec![$( $last_line, )*].join(""))
+            predicates::str::ends_with([$( $last_line, )*].join(""))
         )
     };
 }


### PR DESCRIPTION
Relates to #87

## Summary

Upgrade the version of Rust and related tooling from 1.71.0 to the latest stable version 1.72.0.

## References

- [Rust 1.72 announcement](https://blog.rust-lang.org/2023/08/24/Rust-1.72.0.html)