### PR TITLE
Add SPDX license identifiers to documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Contributing Guidelines
 
 The _rust-rm_ project welcomes contributions and corrections of all forms. This includes

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # `rust-rm`
 
 A CLI like the [GNU version of `rm(1)`] but more modern and designed for humans. Aims to provide an

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Security Policy
 
 The maintainers of the _rust-rm_ project take security issues seriously. We appreciate your efforts


### PR DESCRIPTION
## Summary

Add license identifiers following the [SPDX format](https://spdx.dev/ids/), as already seen in source code files, to all (external and internal) docs files.