### PR TITLE
Update tooling to latest version

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -44,6 +44,6 @@ jobs:
       - name: Install cargo-deny
         uses: taiki-e/install-action@e07b619ce2f1b995233833f3582c6e72d0a50127 # v2.19.0
         with:
-          tool: cargo-deny@0.13.9
+          tool: cargo-deny@0.14.3
       - name: Audit
         run: just ci-audit

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Install cargo-deny
         uses: taiki-e/install-action@e07b619ce2f1b995233833f3582c6e72d0a50127 # v2.19.0
         with:
-          tool: cargo-deny@0.13.9
+          tool: cargo-deny@0.14.3
       - name: Check compliance
         run: just ci-compliance

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install cargo-all-features
         uses: taiki-e/install-action@e07b619ce2f1b995233833f3582c6e72d0a50127 # v2.19.0
         with:
-          tool: cargo-all-features@1.9.0
+          tool: cargo-all-features@1.10.0
       - name: Build
         run: just ci-build
   build-nightly:
@@ -96,7 +96,7 @@ jobs:
       - name: Install cargo-all-features
         uses: taiki-e/install-action@e07b619ce2f1b995233833f3582c6e72d0a50127 # v2.19.0
         with:
-          tool: cargo-all-features@1.9.0
+          tool: cargo-all-features@1.10.0
       - name: Build
         run: just ci-build
   coverage:
@@ -125,7 +125,7 @@ jobs:
       - name: Install cargo-tarpaulin
         uses: taiki-e/install-action@e07b619ce2f1b995233833f3582c6e72d0a50127 # v2.19.0
         with:
-          tool: cargo-tarpaulin@0.26.1
+          tool: cargo-tarpaulin@0.27.1
       - name: Run all tests with coverage
         run: just ci-coverage
       - name: Upload coverage report
@@ -211,7 +211,7 @@ jobs:
       - name: Install cargo-mutants
         uses: taiki-e/install-action@e07b619ce2f1b995233833f3582c6e72d0a50127 # v2.19.0
         with:
-          tool: cargo-mutants@23.6.0
+          tool: cargo-mutants@23.11.1
       - name: Run mutation tests
         run: just ci-mutation
       - name: Upload mutation report
@@ -257,7 +257,7 @@ jobs:
       - name: Install cargo-all-features
         uses: taiki-e/install-action@e07b619ce2f1b995233833f3582c6e72d0a50127 # v2.19.0
         with:
-          tool: cargo-all-features@1.9.0
+          tool: cargo-all-features@1.10.0
       - name: Run all tests
         run: just ci-test
   test-nightly:
@@ -300,7 +300,7 @@ jobs:
       - name: Install cargo-all-features
         uses: taiki-e/install-action@e07b619ce2f1b995233833f3582c6e72d0a50127 # v2.19.0
         with:
-          tool: cargo-all-features@1.9.0
+          tool: cargo-all-features@1.10.0
       - name: Run all tests
         run: just ci-test
   vet:
@@ -327,6 +327,6 @@ jobs:
       - name: Install cargo-all-features
         uses: taiki-e/install-action@e07b619ce2f1b995233833f3582c6e72d0a50127 # v2.19.0
         with:
-          tool: cargo-all-features@1.9.0
+          tool: cargo-all-features@1.10.0
       - name: Vet
         run: just ci-vet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,8 +112,8 @@ To be able to contribute you need the following tooling:
 - [Just] v1;
 - [Rust] and [Cargo] v1.74 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
-- (Optional) [cargo-deny] v0.13.0 or later;
-- (Optional) [cargo-mutants] v23.0.0 or later;
+- (Optional) [cargo-deny] v0.14.2 or later;
+- (Optional) [cargo-mutants] v23.5.0 or later;
 - (Optional) [cargo-tarpaulin] v0.25.0 or later;
 - (Suggested) a code editor with [EditorConfig] support;
 

--- a/Justfile
+++ b/Justfile
@@ -109,6 +109,7 @@ alias v := vet
 		--output _reports/ \
 		--exclude-re cli::run \
 		--exclude-re logging \
+		--exclude-re rm::dispose \
 		--exclude-re 'impl Display' \
 		-- \
 		{{TEST_UNIT_ARGS}} \

--- a/deny.toml
+++ b/deny.toml
@@ -13,7 +13,8 @@ allow = [
     "BSD-3-Clause",
     "Unicode-DFS-2016",
 ]
+confidence-threshold = 0.8
 deny = []
 default = "deny"
+include-dev = true
 unlicensed = "deny"
-confidence-threshold = 0.8


### PR DESCRIPTION
Relates to e3700963141cdd232d4f4d9b14f96fc2dcf258b8, #52, #53, #96

## Summary

- Update `cargo-all-features` from 1.9.0 to 1.10.0.
- Update `cargo-deny` from v0.13.9 to v0.14.3 and bump the minimum version to v0.14.2.
- Update `cargo-mutants` from 23.6.0 to 23.11.1 and update the config to ignore the `rm::dispose` function in which it now finds a mutant.
- Update `cargo-tarpaulin` from 0.26.1 to 0.27.1.