### PR TITLE
Configure default assignee for bot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     schedule:
       interval: daily
       time: "04:00"
+    assignees:
+      - ericcornelissen
     labels:
       - dependencies
   - package-ecosystem: github-actions
@@ -16,6 +18,8 @@ updates:
     schedule:
       interval: daily
       time: "04:00"
+    assignees:
+      - ericcornelissen
     labels:
       - ci/cd
       - dependencies


### PR DESCRIPTION
## Summary

Configure Dependabot to automatically set the default assignee for Pull Request they generating. This is based on historical precedence for [Pull Requests from Dependabot](https://github.com/ericcornelissen/rust-rm/pulls?q=is%3Apr+author%3Aapp%2Fdependabot). The configuration changes are based on the [Dependabot docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#assignees).