### PR TITLE
Bump Rust toolchain channel from 1.74 to 1.75

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ To be able to contribute you need the following tooling:
 
 - [git] v2;
 - [Just] v1;
-- [Rust] and [Cargo] v1.74 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
+- [Rust] and [Cargo] v1.75 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.14.2 or later;
 - (Optional) [cargo-mutants] v23.5.0 or later;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
 
 [[package]]
 name = "rust-rm"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anstream 0.6.5",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "rust-rm"
-version = "0.1.0"
 description = "A modern alternative to the rm(1) command"
 license = "Apache-2.0"
 authors = ["Eric Cornelissen <ericornelissen@gmail.com>"]

--- a/Justfile
+++ b/Justfile
@@ -109,6 +109,7 @@ alias v := vet
 		--output _reports/ \
 		--exclude-re cli::run \
 		--exclude-re logging \
+		--exclude-re 'main -> ExitCode' \
 		--exclude-re rm::dispose \
 		--exclude-re 'impl Display' \
 		-- \

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ rm -fq file1 file2
 
 ## Build from Source
 
-To build from source you need [Rust] and [Cargo], v1.74 or higher, installed on your system. Then
+To build from source you need [Rust] and [Cargo], v1.75 or higher, installed on your system. Then
 run the command:
 
 ```shell

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Check out rustup at: https://rust-lang.github.io/rustup/index.html
 
 [toolchain]
-channel = "1.74.0"
+channel = "1.75.0"
 components = [
     "cargo",
     "clippy",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2740,7 +2740,7 @@ mod rm {
         trace!("remove {entry}");
 
         if entry.is_dir() && !fs::is_empty(&entry) {
-            // This case is handled explicitly because, as of Rust 1.74, the `io::ErrorKind` variant
+            // This case is handled explicitly because, as of Rust 1.75, the `io::ErrorKind` variant
             // is still experimental (gate "io_error_more") and so would result in an unknown error.
             // This implementation leaves a possibility for a TOCTOU issue, but this will be handled
             // safely as `std::fs::remove_dir` doesn't remove non-empty directories.


### PR DESCRIPTION
Relates to #145

## Summary

Upgrade the version of Rust and related tooling from 1.74.0 to 1.75.0, which was recently released.

## References

- [Rust 1.75 announcement](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html)
- [Cargo 1.75 release notes](https://github.com/rust-lang/cargo/blob/2ed2dbd8ce892f041140362aec7d4ca6106f4da3/CHANGELOG.md#cargo-175-2023-12-28)
