### PR TITLE
Use `macos-14` as MacOS runners in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,13 +18,13 @@ jobs:
       matrix:
         include:
           - target: aarch64-apple-darwin
-            os: macos-12
+            os: macos-14
             os-name: MacOS
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04
             os-name: Ubuntu
           - target: x86_64-apple-darwin
-            os: macos-12
+            os: macos-14
             os-name: MacOS
           - target: x86_64-pc-windows-msvc
             os: windows-2022

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-13
+            os: macos-14
           - name: Ubuntu
             os: ubuntu-22.04
           - name: Windows
@@ -67,7 +67,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-13
+            os: macos-14
           - name: Ubuntu
             os: ubuntu-22.04
           - name: Windows
@@ -264,7 +264,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-13
+            os: macos-14
           - name: Ubuntu
             os: ubuntu-22.04
           - name: Windows
@@ -304,7 +304,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-13
+            os: macos-14
           - name: Ubuntu
             os: ubuntu-22.04
           - name: Windows


### PR DESCRIPTION
Relates to #18

## Summary

Update all continuous integration jobs that run on MacOS to use `macos-14` instead of `macos-13`. ~~This was released yesterday and is still in beta, hence this is just for trying it out and seeing if it works.~~ **EDIT:** As of 2024-04-01 this is generally available.

See also
- <https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/>
- <https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/>