### PR TITLE
Bump Rust toolchain channel from 1.75 to 1.76

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ To be able to contribute you need the following tooling:
 
 - [git] v2;
 - [Just] v1;
-- [Rust] and [Cargo] v1.75 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
+- [Rust] and [Cargo] v1.76 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.14.2 or later;
 - (Optional) [cargo-mutants] v23.5.0 or later;

--- a/Justfile
+++ b/Justfile
@@ -201,8 +201,11 @@ _profile_prepare:
 		--deny clippy::expect_used \
 		--deny clippy::let_underscore_untyped \
 		--deny clippy::if_then_some_else_none \
+		--deny clippy::infinite_loop \
+		--deny clippy::iter_over_hash_type \
 		--deny clippy::impl_trait_in_params \
 		--deny clippy::indexing_slicing \
+		--deny clippy::missing_asserts_for_indexing \
 		--deny clippy::missing_docs_in_private_items \
 		--deny clippy::missing_enforced_import_renames \
 		--deny clippy::print_stderr \

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ rm -fq file1 file2
 
 ## Build from Source
 
-To build from source you need [Rust] and [Cargo], v1.75 or higher, installed on your system. Then
+To build from source you need [Rust] and [Cargo], v1.76 or higher, installed on your system. Then
 run the command:
 
 ```shell

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Check out rustup at: https://rust-lang.github.io/rustup/index.html
 
 [toolchain]
-channel = "1.75.0"
+channel = "1.76.0"
 components = [
     "cargo",
     "clippy",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2740,7 +2740,7 @@ mod rm {
         trace!("remove {entry}");
 
         if entry.is_dir() && !fs::is_empty(&entry) {
-            // This case is handled explicitly because, as of Rust 1.75, the `io::ErrorKind` variant
+            // This case is handled explicitly because, as of Rust 1.76, the `io::ErrorKind` variant
             // is still experimental (gate "io_error_more") and so would result in an unknown error.
             // This implementation leaves a possibility for a TOCTOU issue, but this will be handled
             // safely as `std::fs::remove_dir` doesn't remove non-empty directories.


### PR DESCRIPTION
Relates to #162

## Summary

Upgrade the version of Rust and related tooling from 1.75.0 to 1.76.0, which was recently released.

## References

- [Rust 1.76 announcement](https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html)
- [Clippy 1.76 release notes](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-176)