### PR TITLE
Bump Rust toolchain channel from 1.76 to 1.77

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ To be able to contribute you need the following tooling:
 
 - [git] v2;
 - [Just] v1;
-- [Rust] and [Cargo] v1.76 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
+- [Rust] and [Cargo] v1.77 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.14.2 or later;
 - (Optional) [cargo-mutants] v23.5.0 or later;

--- a/Justfile
+++ b/Justfile
@@ -198,6 +198,7 @@ _profile_prepare:
 		--deny clippy::arithmetic_side_effects \
 		--deny clippy::dbg_macro \
 		--deny clippy::disallowed_script_idents \
+		--deny clippy::empty_enum_variants_with_brackets \
 		--deny clippy::expect_used \
 		--deny clippy::let_underscore_untyped \
 		--deny clippy::if_then_some_else_none \

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ rm -fq file1 file2
 
 ## Build from Source
 
-To build from source you need [Rust] and [Cargo], v1.76 or higher, installed on your system. Then
+To build from source you need [Rust] and [Cargo], v1.77 or higher, installed on your system. Then
 run the command:
 
 ```shell

--- a/clippy.toml
+++ b/clippy.toml
@@ -22,6 +22,17 @@ too-many-arguments-threshold = 3
 too-many-lines-threshold = 100
 
 absolute-paths-allowed-crates = ["log", "trash"]
+allowed-duplicate-crates = [
+    "windows",
+    "windows-targets",
+    "windows_aarch64_gnullvm",
+    "windows_aarch64_msvc",
+    "windows_i686_gnu",
+    "windows_i686_msvc",
+    "windows_x86_64_gnu",
+    "windows_x86_64_gnullvm",
+    "windows_x86_64_msvc",
+]
 
 arithmetic-side-effects-allowed = []
 arithmetic-side-effects-allowed-binary = []

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Check out rustup at: https://rust-lang.github.io/rustup/index.html
 
 [toolchain]
-channel = "1.76.0"
+channel = "1.77.0"
 components = [
     "cargo",
     "clippy",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2755,7 +2755,7 @@ mod rm {
         trace!("remove {entry}");
 
         if entry.is_dir() && !fs::is_empty(&entry) {
-            // This case is handled explicitly because, as of Rust 1.76, the `io::ErrorKind` variant
+            // This case is handled explicitly because, as of Rust 1.77, the `io::ErrorKind` variant
             // is still experimental (gate "io_error_more") and so would result in an unknown error.
             // This implementation leaves a possibility for a TOCTOU issue, but this will be handled
             // safely as `std::fs::remove_dir` doesn't remove non-empty directories.


### PR DESCRIPTION
Relates to #190

## Summary

Upgrade the version of Rust and related tooling from 1.76.0 to 1.77.0, which was recently released.

## References

- [Rust 1.77 announcement](https://blog.rust-lang.org/2024/03/21/Rust-1.77.0.html)
- [Clippy 1.77 release notes](https://github.com/rust-lang/rust-clippy/blob/12f7c17ae0e9137a4b470d17c5ed204458f4bab2/CHANGELOG.md#rust-177)