### PR TITLE
Define a development image

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ insert_final_newline=true
 max_line_length=100
 trim_trailing_whitespace=true
 
+[Containerfile*]
+indent_style=tab
+
 [Justfile]
 indent_style=tab
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,29 @@
+name: Dev
+on:
+  pull_request:
+    paths:
+      - .github/workflows/dev.yml
+      - Cargo.lock
+      - Cargo.toml
+      - Containerfile.dev
+      - Justfile
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+
+jobs:
+  container:
+    name: Container
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      - name: Install Just
+        uses: taiki-e/install-action@bd71f121e3951933204a4d1cf9256d934f5600a5 # v2.27.0
+        with:
+          tool: just@1
+      - name: Build
+        run: just dev-img

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Install cargo-tarpaulin
         uses: taiki-e/install-action@bd71f121e3951933204a4d1cf9256d934f5600a5 # v2.27.0
         with:
-          tool: cargo-tarpaulin@0.27.3
+          tool: cargo-tarpaulin@0.28.0
       - name: Run all tests with coverage
         run: just ci-coverage
       - name: Upload coverage report
@@ -213,7 +213,7 @@ jobs:
       - name: Install cargo-mutants
         uses: taiki-e/install-action@bd71f121e3951933204a4d1cf9256d934f5600a5 # v2.27.0
         with:
-          tool: cargo-mutants@24.2.0
+          tool: cargo-mutants@24.3.0
       - name: Run mutation tests
         run: just ci-mutation
       - name: Upload mutation report

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT-0
+
+FROM docker.io/rust:1.77.0-alpine3.19
+
+RUN apk add --no-cache \
+	bash git just libressl-dev musl-dev perl
+
+RUN cargo install \
+	cargo-all-features@1.10.0 \
+	cargo-deny@0.14.11 \
+	cargo-mutants@24.3.0 \
+	cargo-tarpaulin@0.28.0
+
+WORKDIR /rust-rm
+COPY ./ ./
+
+ENTRYPOINT ["/bin/bash"]

--- a/Justfile
+++ b/Justfile
@@ -74,6 +74,23 @@ alias v := vet
 		{{FEATURES}}
 	mv _reports/coverage/tarpaulin-report.html _reports/coverage/coverage-unit.html
 
+# Run an ephemeral development environment container
+@dev-env engine="docker":
+	just dev-img {{engine}}
+	{{engine}} run -it \
+		--rm \
+		--workdir '/rust-rm' \
+		--mount "type=bind,source=$(pwd),target=/rust-rm" \
+		--name 'rust-rm-dev-env' \
+		'rust-rm-dev-img'
+
+# Build a development environment container image
+@dev-img engine="docker":
+	{{engine}} build \
+		--file 'Containerfile.dev' \
+		--tag 'rust-rm-dev-img' \
+		.
+
 # Generate documentation for the project and dependencies
 @docs:
 	cargo doc \


### PR DESCRIPTION
Relates to #191

## Summary

Add a `Containerfile` for a development image that will come installed with all necessary and optional project dependencies for easier development.

As of writing this is a WIP that is blocked by an incompatibility of a transitive dependency of some of the optional dependencies with the alpine-based container.