### PR TITLE
Upgrade the Ubuntu-based runner used in CI to 24.04

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   cargo:
     name: Cargo
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   license:
     name: License
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -17,7 +17,7 @@ permissions: read-all
 jobs:
   container:
     name: Container
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
             os: macos-14
             os-name: MacOS
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             os-name: Ubuntu
           - target: x86_64-apple-darwin
             os: macos-14
@@ -30,7 +30,7 @@ jobs:
             os: windows-2022
             os-name: Windows
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             os-name: Ubuntu
     steps:
       - name: Checkout repository
@@ -80,7 +80,7 @@ jobs:
           retention-days: 1
   github-release:
     name: GitHub Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write # To create a GitHub Release
     needs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
           - name: MacOS
             os: macos-14
           - name: Ubuntu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - name: Windows
             os: windows-2022
     steps:
@@ -69,7 +69,7 @@ jobs:
           - name: MacOS
             os: macos-14
           - name: Ubuntu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - name: Windows
             os: windows-2022
     steps:
@@ -101,7 +101,7 @@ jobs:
         run: just ci-build
   coverage:
     name: Coverage
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - test
     steps:
@@ -137,7 +137,7 @@ jobs:
           retention-days: 7
   docs:
     name: Docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -160,7 +160,7 @@ jobs:
         run: just ci-docs
   fmt:
     name: Fmt
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -183,7 +183,7 @@ jobs:
         run: just ci-fmt
   mutation:
     name: Mutation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - test
     steps:
@@ -219,7 +219,7 @@ jobs:
           retention-days: 7
   reproducible:
     name: Reproducible build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - build
     steps:
@@ -260,7 +260,7 @@ jobs:
           - name: MacOS
             os: macos-14
           - name: Ubuntu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - name: Windows
             os: windows-2022
     steps:
@@ -300,7 +300,7 @@ jobs:
           - name: MacOS
             os: macos-14
           - name: Ubuntu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - name: Windows
             os: windows-2022
     steps:
@@ -332,7 +332,7 @@ jobs:
         run: just ci-test
   vet:
     name: Vet
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2


### PR DESCRIPTION
## Summary

Upgrade the Ubuntu-based runner used in CI from 22.04 to 24.04. ~~**NOTE:** As of writing this runner is still in beta, so this should not be merged.~~