### PR TITLE
Bump Rust toolchain channel from 1.78 to 1.79

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ To be able to contribute you need the following tooling:
 
 - [git] v2;
 - [Just] v1;
-- [Rust] and [Cargo] v1.78 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
+- [Rust] and [Cargo] v1.79 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.14.2 or later;
 - (Optional) [cargo-mutants] v23.5.0 or later;

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT-0
 
-FROM docker.io/rust:1.78.0-alpine3.19
+FROM docker.io/rust:1.79.0-alpine3.19
 
 RUN apk add --no-cache \
 	bash git just libressl-dev musl-dev perl

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ rm -fq file1 file2
 
 ## Build from Source
 
-To build from source you need [Rust] and [Cargo], v1.78 or higher, installed on your system. Then
+To build from source you need [Rust] and [Cargo], v1.79 or higher, installed on your system. Then
 run the command:
 
 ```shell

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Check out rustup at: https://rust-lang.github.io/rustup/index.html
 
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"
 components = [
     "cargo",
     "clippy",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2755,7 +2755,7 @@ mod rm {
         trace!("remove {entry}");
 
         if entry.is_dir() && !fs::is_empty(&entry) {
-            // This case is handled explicitly because, as of Rust 1.78, the `io::ErrorKind` variant
+            // This case is handled explicitly because, as of Rust 1.79, the `io::ErrorKind` variant
             // is still experimental (gate "io_error_more") and so would result in an unknown error.
             // This implementation leaves a possibility for a TOCTOU issue, but this will be handled
             // safely as `std::fs::remove_dir` doesn't remove non-empty directories.

--- a/tests/interactive_test.rs
+++ b/tests/interactive_test.rs
@@ -624,7 +624,7 @@ fn not_found() -> TestResult {
     })
 }
 
-/// Re-usable test for validating the behaviour of a correct negative answer.
+/// Re-usable test for validating the behavior of a correct negative answer.
 fn test_answer_no(answer: &str) -> TestResult {
     let filename = "file";
 
@@ -656,7 +656,7 @@ fn test_answer_no(answer: &str) -> TestResult {
     })
 }
 
-/// Re-usable test for validating the behaviour of a correct positive answer.
+/// Re-usable test for validating the behavior of a correct positive answer.
 fn test_answer_yes(answer: &str) -> TestResult {
     let filename = "file";
 


### PR DESCRIPTION
Relates to #234

## Summary 

Upgrade the version of Rust and related tooling from 1.78.0 to 1.79.0, which was recently released: <https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html>.