### PR TITLE
Bump Rust toolchain channel from 1.80 to 1.81

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ To be able to contribute you need the following tooling:
 
 - [git] v2;
 - [Just] v1;
-- [Rust] and [Cargo] v1.80 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
+- [Rust] and [Cargo] v1.81 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.14.2 or later;
 - (Optional) [cargo-mutants] v23.5.0 or later;

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT-0
 
-FROM docker.io/rust:1.80.0-alpine3.19
+FROM docker.io/rust:1.81.0-alpine3.20
 
 RUN apk add --no-cache \
 	bash git just libressl-dev musl-dev perl

--- a/Justfile
+++ b/Justfile
@@ -213,10 +213,12 @@ _profile_prepare:
 		--deny clippy::absolute_paths \
 		--deny clippy::allow_attributes_without_reason \
 		--deny clippy::arithmetic_side_effects \
+		--deny clippy::cfg_not_test \
 		--deny clippy::dbg_macro \
 		--deny clippy::disallowed_script_idents \
 		--deny clippy::empty_enum_variants_with_brackets \
 		--deny clippy::expect_used \
+		--deny clippy::field_scoped_visibility_modifiers \
 		--deny clippy::let_underscore_untyped \
 		--deny clippy::if_then_some_else_none \
 		--deny clippy::infinite_loop \

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ rm -fq file1 file2
 
 ## Build from Source
 
-To build from source you need [Rust] and [Cargo], v1.80 or higher, installed on your system. Then
+To build from source you need [Rust] and [Cargo], v1.81 or higher, installed on your system. Then
 run the command:
 
 ```shell

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Check out rustup at: https://rust-lang.github.io/rustup/index.html
 
 [toolchain]
-channel = "1.80.0"
+channel = "1.81.0"
 components = [
     "cargo",
     "clippy",

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -55,7 +55,7 @@ use assert_fs::TempDir;
 ///     assert_eq!(false, has_exactly_lines!("line1\n", "line3\n"; "line2\n").eval(test_str));
 /// }
 /// ```
-#[allow(unused_macros)]
+#[allow(unused_macros, reason = "used in other test files")]
 macro_rules! has_exactly_lines {
     ($($line:expr),* $(,)?) => {
         // Base predicate.
@@ -123,7 +123,7 @@ macro_rules! has_exactly_lines {
 ///     assert_eq!(false, has_lines!("line1\n"; "line2\n").eval(test_str));
 /// }
 /// ```
-#[allow(unused_macros)]
+#[allow(unused_macros, reason = "used in other test files")]
 macro_rules! has_lines {
     ($($line:expr),* $(,)?) => {
         // Base predicate.
@@ -138,7 +138,7 @@ macro_rules! has_lines {
     };
 }
 
-#[allow(unused_imports)]
+#[allow(unused_imports, reason = "used in other test files")]
 pub(crate) use {has_exactly_lines, has_lines};
 
 /// Test helpers to generate strings used by the CLI to prompt the user.


### PR DESCRIPTION
Relates to #264

## Summary

Upgrade the version of Rust and related tooling from 1.80.0 to 1.81.0, which was recently released, see <https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html>.