### PR TITLE
Bump Rust toolchain channel from 1.81 to 1.82

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Install cargo-tarpaulin
         uses: taiki-e/install-action@3e71e7135de310b70bc22dccb4d275acde8e055a # v2.42.0
         with:
-          tool: cargo-tarpaulin@0.28.0
+          tool: cargo-tarpaulin@0.31.2
       - name: Run all tests with coverage
         run: just ci-coverage
       - name: Upload coverage report

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ To be able to contribute you need the following tooling:
 
 - [git] v2;
 - [Just] v1;
-- [Rust] and [Cargo] v1.81 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
+- [Rust] and [Cargo] v1.82 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.14.2 or later;
 - (Optional) [cargo-mutants] v23.5.0 or later;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ To be able to contribute you need the following tooling:
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.14.2 or later;
 - (Optional) [cargo-mutants] v23.5.0 or later;
-- (Optional) [cargo-tarpaulin] v0.25.0 or later;
+- (Optional) [cargo-tarpaulin] v0.31.2 or later;
 - (Suggested) a code editor with [EditorConfig] support;
 
 [cargo]: https://doc.rust-lang.org/stable/cargo/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Eric Cornelissen <ericornelissen@gmail.com>"]
 repository = "https://github.com/ericcornelissen/rust-rm"
 keywords = ["cli", "rm", "trash"]
 categories = ["development-tools", "filesystem"]
+rust-version = "1.82"
 edition = "2021"
 
 [features]

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -11,7 +11,7 @@ RUN cargo install \
 	cargo-all-features@1.10.0 \
 	cargo-deny@0.14.11 \
 	cargo-mutants@24.3.0 \
-	cargo-tarpaulin@0.28.0
+	cargo-tarpaulin@0.31.2
 
 WORKDIR /rust-rm
 COPY ./ ./

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: MIT-0
 
-FROM docker.io/rust:1.81.0-alpine3.20
+FROM docker.io/rust:1.82.0-alpine3.20
 
 RUN apk add --no-cache \
-	bash git just libressl-dev musl-dev perl
+	bash git just libressl-dev musl-dev perl \
+	&& \
+	git config --global --add safe.directory /rust-rm
 
 RUN cargo install \
 	cargo-all-features@1.10.0 \

--- a/Justfile
+++ b/Justfile
@@ -228,6 +228,7 @@ _profile_prepare:
 		--deny clippy::missing_asserts_for_indexing \
 		--deny clippy::missing_docs_in_private_items \
 		--deny clippy::missing_enforced_import_renames \
+		--deny clippy::pathbuf_init_then_push \
 		--deny clippy::print_stderr \
 		--deny clippy::print_stdout \
 		--deny clippy::rc_buffer \
@@ -235,9 +236,8 @@ _profile_prepare:
 		--deny clippy::ref_patterns \
 		--deny clippy::renamed_function_params \
 		--deny clippy::string_lit_chars_any \
-		--deny clippy::unwrap_used \
-		\
-		--allow clippy::ignored_unit_patterns
+		--deny clippy::unused_result_ok \
+		--deny clippy::unwrap_used
 
 @_vet_verify_project:
 	echo 'Running "cargo verify-project"...'

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ rm -fq file1 file2
 
 ## Build from Source
 
-To build from source you need [Rust] and [Cargo], v1.81 or higher, installed on your system. Then
+To build from source you need [Rust] and [Cargo], v1.82 or higher, installed on your system. Then
 run the command:
 
 ```shell

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Check out rustup at: https://rust-lang.github.io/rustup/index.html
 
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 components = [
     "cargo",
     "clippy",

--- a/src/main.rs
+++ b/src/main.rs
@@ -988,7 +988,7 @@ mod cli {
             type Parameters = ();
             type Strategy = BoxedStrategy<Self>;
 
-            fn arbitrary_with(_: ()) -> Self::Strategy {
+            fn arbitrary_with((): ()) -> Self::Strategy {
                 const KNOWN_FLAG_PATTERN: &str = "\
                     --blind|-b|\
                     --dir|-d|\
@@ -1033,7 +1033,7 @@ mod cli {
             type Parameters = ();
             type Strategy = BoxedStrategy<Self>;
 
-            fn arbitrary_with(_: ()) -> Self::Strategy {
+            fn arbitrary_with((): ()) -> Self::Strategy {
                 let size_range = 1..=16;
                 prop::collection::vec(TestArg::arbitrary(), size_range)
                     .prop_map(|v| Self(v.into_iter().map(TestArg::inner).collect()))
@@ -1075,7 +1075,7 @@ mod cli {
             type Parameters = ();
             type Strategy = BoxedStrategy<Self>;
 
-            fn arbitrary_with(_: ()) -> Self::Strategy {
+            fn arbitrary_with((): ()) -> Self::Strategy {
                 let size_range = 1..=16;
                 prop::collection::vec(TestArg::arbitrary(), size_range)
                     .prop_flat_map(|vec| (0..vec.len(), Just(vec)))
@@ -1100,7 +1100,7 @@ mod cli {
             type Parameters = ();
             type Strategy = BoxedStrategy<Self>;
 
-            fn arbitrary_with(_: ()) -> Self::Strategy {
+            fn arbitrary_with((): ()) -> Self::Strategy {
                 const KNOWN_VAR_PATTERN: &str = "RUST_RM_GNU_MODE|DEBUG";
                 const GENERAL_VAR_PATTERN: &str = "[a-zA-Z_]+";
 
@@ -1135,7 +1135,7 @@ mod cli {
             type Parameters = ();
             type Strategy = BoxedStrategy<Self>;
 
-            fn arbitrary_with(_: ()) -> Self::Strategy {
+            fn arbitrary_with((): ()) -> Self::Strategy {
                 let size_range = 1..=16;
                 prop::collection::vec(TestVar::arbitrary(), size_range)
                     .prop_map(|v| Self(v.into_iter().map(TestVar::inner).collect()))
@@ -1165,7 +1165,7 @@ mod cli {
             type Parameters = ();
             type Strategy = BoxedStrategy<Self>;
 
-            fn arbitrary_with(_: ()) -> Self::Strategy {
+            fn arbitrary_with((): ()) -> Self::Strategy {
                 let size_range = 1..=16;
                 prop::collection::vec(TestVar::arbitrary(), size_range)
                     .prop_flat_map(|vec| (0..vec.len(), Just(vec)))
@@ -2758,7 +2758,7 @@ mod rm {
         trace!("remove {entry}");
 
         if entry.is_dir() && !fs::is_empty(&entry) {
-            // This case is handled explicitly because, as of Rust 1.81, the `io::ErrorKind` variant
+            // This case is handled explicitly because, as of Rust 1.82, the `io::ErrorKind` variant
             // is still experimental (gate "io_error_more") and so would result in an unknown error.
             // This implementation leaves a possibility for a TOCTOU issue, but this will be handled
             // safely as `std::fs::remove_dir` doesn't remove non-empty directories.
@@ -3284,7 +3284,7 @@ mod transform {
             type Parameters = ();
             type Strategy = BoxedStrategy<Self>;
 
-            fn arbitrary_with(_: ()) -> Self::Strategy {
+            fn arbitrary_with((): ()) -> Self::Strategy {
                 "(\\.\\.?SEPARATOR)*\\."
                     .prop_map(|v| CurrentDirPath(v.replace("SEPARATOR", MAIN_SEPARATOR_STR)))
                     .boxed()
@@ -3301,7 +3301,7 @@ mod transform {
             type Parameters = ();
             type Strategy = BoxedStrategy<Self>;
 
-            fn arbitrary_with(_: ()) -> Self::Strategy {
+            fn arbitrary_with((): ()) -> Self::Strategy {
                 "(\\.\\.?SEPARATOR)*\\.\\."
                     .prop_map(|v| ParentDirPath(v.replace("SEPARATOR", MAIN_SEPARATOR_STR)))
                     .boxed()


### PR DESCRIPTION
Relates to #277

## Summary

Upgrade the version of Rust and related tooling from 1.81.0 to 1.82.0, which was recently released, see <https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html>.