### PR TITLE
Create reproducibility command

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -240,14 +240,8 @@ jobs:
         uses: taiki-e/install-action@3e71e7135de310b70bc22dccb4d275acde8e055a # v2.42.0
         with:
           tool: just@1
-      - name: Build
-        run: just build
-      - name: Compute checksum
-        run: shasum target/release/rust-rm | tee checksums.txt
-      - name: Rebuild
-        run: just clean build
-      - name: Verify checksum
-        run: shasum --check checksums.txt --strict
+      - name: Check reproducibility
+        run: just reproducible
   test:
     name: Test (${{ matrix.name }})
     runs-on: ${{ matrix.os }}

--- a/Justfile
+++ b/Justfile
@@ -149,6 +149,13 @@ _profile_prepare:
 	`mkdir profile_fs/nested_dir`;
 	for(1..750) { `touch profile_fs/nested_dir/file-$_`; }
 
+# Check if the build is reproducible
+@reproducible: clean
+	just build
+	shasum target/release/rust-rm | tee checksums.txt
+	just clean build
+	shasum --check checksums.txt --strict
+
 # Run rm with the given arguments
 @run *ARGS:
 	cargo run \


### PR DESCRIPTION
Relates to #149

## Summary

Move the reproducibility check from the CI into the `Justfile` and use this command in CI too. This makes it easier to run the check locally.