### PR TITLE
Try out Rust edition 2024

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -38,7 +38,10 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust toolchain
-        run: rustup show
+        run: |
+          rustup install nightly
+          rustup override set nightly
+          rustup show
       - name: Install Just
         uses: taiki-e/install-action@6aa8b420a527920162babdd71d780f9e5b3b4bc8 # v2.46.1
         with:

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -35,7 +35,10 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust toolchain
-        run: rustup show
+        run: |
+          rustup install nightly
+          rustup override set nightly
+          rustup show
       - name: Install Just
         uses: taiki-e/install-action@6aa8b420a527920162babdd71d780f9e5b3b4bc8 # v2.46.1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,10 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust toolchain
-        run: rustup show
+        run: |
+          rustup install nightly
+          rustup override set nightly
+          rustup show
       - name: Install Just
         uses: taiki-e/install-action@6aa8b420a527920162babdd71d780f9e5b3b4bc8 # v2.46.1
         with:
@@ -123,7 +126,10 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust toolchain
-        run: rustup show
+        run: |
+          rustup install nightly
+          rustup override set nightly
+          rustup show
       - name: Install Just
         uses: taiki-e/install-action@6aa8b420a527920162babdd71d780f9e5b3b4bc8 # v2.46.1
         with:
@@ -159,7 +165,10 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust toolchain
-        run: rustup show
+        run: |
+          rustup install nightly
+          rustup override set nightly
+          rustup show
       - name: Install Just
         uses: taiki-e/install-action@6aa8b420a527920162babdd71d780f9e5b3b4bc8 # v2.46.1
         with:
@@ -184,7 +193,10 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust toolchain
-        run: rustup show
+        run: |
+          rustup install nightly
+          rustup override set nightly
+          rustup show
       - name: Install Just
         uses: taiki-e/install-action@6aa8b420a527920162babdd71d780f9e5b3b4bc8 # v2.46.1
         with:
@@ -211,7 +223,10 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust toolchain
-        run: rustup show
+        run: |
+          rustup install nightly
+          rustup override set nightly
+          rustup show
       - name: Install Just
         uses: taiki-e/install-action@6aa8b420a527920162babdd71d780f9e5b3b4bc8 # v2.46.1
         with:
@@ -249,7 +264,10 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust toolchain
-        run: rustup show
+        run: |
+          rustup install nightly
+          rustup override set nightly
+          rustup show
       - name: Install Just
         uses: taiki-e/install-action@6aa8b420a527920162babdd71d780f9e5b3b4bc8 # v2.46.1
         with:
@@ -286,7 +304,10 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust toolchain
-        run: rustup show
+        run: |
+          rustup install nightly
+          rustup override set nightly
+          rustup show
       - name: Install Just
         uses: taiki-e/install-action@6aa8b420a527920162babdd71d780f9e5b3b4bc8 # v2.46.1
         with:
@@ -360,7 +381,10 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust toolchain
-        run: rustup show
+        run: |
+          rustup install nightly
+          rustup override set nightly
+          rustup show
       - name: Install Just
         uses: taiki-e/install-action@6aa8b420a527920162babdd71d780f9e5b3b4bc8 # v2.46.1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ To be able to contribute you need the following tooling:
 
 - [git] v2;
 - [Just] v1;
-- [Rust] and [Cargo] v1.83 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
+- [Rust] and [Cargo] v1.83 (edition 2024) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.14.2 or later;
 - (Optional) [cargo-mutants] v23.5.0 or later;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ proptest-attr-macro = "1.0.0"
 proptest-derive = "0.5.0"
 
 [lints.rust]
-unexpected_cfgs = { level = "deny", check-cfg = ['cfg(tarpaulin_include)'] }
 
 [profile.release]
 debug = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Eric Cornelissen <ericornelissen@gmail.com>"]
 repository = "https://github.com/ericcornelissen/rust-rm"
 keywords = ["cli", "rm", "trash"]
 categories = ["development-tools", "filesystem"]
-rust-version = "1.83"
-edition = "2021"
+rust-version = "1.85"
+edition = "2024"
 
 [features]
 default = ["gnu-mode", "trash"]

--- a/Justfile
+++ b/Justfile
@@ -10,25 +10,25 @@ alias v := vet
 
 # Audit the project for known vulnerabilities
 @audit:
-	cargo deny check advisories \
+	cargo +nightly deny check advisories \
 		--config ./deny.toml
 
 # Build the rm binary
 @build:
-	cargo build \
+	cargo +nightly build \
 		{{BUILD_ARGS}} \
 		{{FEATURES}}
 
 [private]
 @build-each:
-	cargo build-all-features \
+	cargo +nightly build-all-features \
 		{{BUILD_ARGS}}
 
 # Reset the repository to a clean state
 @clean: _clean_cargo _clean_git
 
 @_clean_cargo:
-	cargo clean
+	cargo +nightly clean
 
 @_clean_git:
 	git clean -fx \
@@ -45,12 +45,12 @@ alias v := vet
 
 # Check license compliance
 @compliance:
-	cargo deny check licenses \
+	cargo +nightly deny check licenses \
 		--config ./deny.toml
 
 # Produce a coverage report for all tests
 @coverage:
-	cargo tarpaulin \
+	cargo +nightly tarpaulin \
 		{{COVERAGE_ARGS}} \
 		{{TEST_FEATURES}} \
 		{{FEATURES}}
@@ -58,7 +58,7 @@ alias v := vet
 
 # Produce a coverage report for integration tests
 @coverage-integration:
-	cargo tarpaulin \
+	cargo +nightly tarpaulin \
 		{{COVERAGE_ARGS}} \
 		{{TEST_INTEGRATION_ARGS}} \
 		{{TEST_FEATURES}} \
@@ -67,7 +67,7 @@ alias v := vet
 
 # Produce a coverage report for unit tests
 @coverage-unit:
-	cargo tarpaulin \
+	cargo +nightly tarpaulin \
 		{{COVERAGE_ARGS}} \
 		{{TEST_UNIT_ARGS}} \
 		{{TEST_FEATURES}} \
@@ -93,16 +93,16 @@ alias v := vet
 
 # Generate documentation for the project and dependencies
 @docs:
-	cargo doc \
+	cargo +nightly doc \
 		{{DOCS_ARGS}}
 
 # Format the source code
 @fmt:
-	cargo fmt
+	cargo +nightly fmt
 
 [private]
 @fmt-check:
-	cargo fmt --check
+	cargo +nightly fmt --check
 
 # Get the (minimum) number of lines of source code
 @loc:
@@ -122,7 +122,7 @@ alias v := vet
 
 # Run mutation tests
 @mutation:
-	cargo mutants \
+	cargo +nightly mutants \
 		--output _reports/ \
 		--exclude-re cli::run \
 		--exclude-re logging \
@@ -136,7 +136,7 @@ alias v := vet
 # Profile with visualization using <https://github.com/brendangregg/FlameGraph>
 [private]
 @profile: _profile_prepare
-	cargo build {{FEATURES}}
+	cargo +nightly build {{FEATURES}}
 	perf record -F99 --call-graph dwarf -- \
 		just run --dir --recursive --force profile_fs
 	perf script | ./stackcollapse-perf.pl | ./flamegraph.pl > perf.svg
@@ -158,21 +158,21 @@ _profile_prepare:
 
 # Run rm with the given arguments
 @run *ARGS:
-	cargo run \
+	cargo +nightly run \
 		{{FEATURES}} \
 		-- \
 		{{ARGS}}
 
 # Run all tests
 @test:
-	cargo test \
+	cargo +nightly test \
 		{{TEST_ARGS}} \
 		{{TEST_FEATURES}} \
 		{{FEATURES}}
 
 # Run all integration tests
 @test-integration:
-	cargo test \
+	cargo +nightly test \
 		{{TEST_ARGS}} \
 		{{TEST_INTEGRATION_ARGS}} \
 		{{TEST_FEATURES}} \
@@ -180,7 +180,7 @@ _profile_prepare:
 
 # Run all unit tests
 @test-unit:
-	cargo test \
+	cargo +nightly test \
 		{{TEST_ARGS}} \
 		{{TEST_UNIT_ARGS}} \
 		{{TEST_FEATURES}} \
@@ -188,7 +188,7 @@ _profile_prepare:
 
 [private]
 @test-each:
-	cargo test-all-features \
+	cargo +nightly test-all-features \
 		{{TEST_ARGS}} \
 		{{TEST_FEATURES}}
 
@@ -200,12 +200,12 @@ _profile_prepare:
 
 @_vet_check:
 	echo 'Running "cargo check"...'
-	cargo {{ if ci == TRUE { "check-all-features" } else { "check" } }} \
+	cargo +nightly {{ if ci == TRUE { "check-all-features" } else { "check" } }} \
 		{{CI_ONLY_CARGO_ARGS}}
 
 @_vet_clippy:
 	echo 'Running "cargo clippy"...'
-	cargo clippy \
+	cargo +nightly clippy \
 		--no-deps \
 		--tests \
 		-- \
@@ -249,7 +249,7 @@ _profile_prepare:
 
 @_vet_verify_project:
 	echo 'Running "cargo verify-project"...'
-	cargo verify-project \
+	cargo +nightly verify-project \
 		--quiet \
 		{{CI_ONLY_CARGO_ARGS}}
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 # Check out rustfmt at: https://rust-lang.github.io/rustfmt/
 
-edition = "2021"
+edition = "2024"
 
 disable_all_formatting = false
 newline_style = "Unix"

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -57,7 +57,7 @@ use assert_fs::TempDir;
 /// ```
 #[allow(unused_macros, reason = "used in other test files")]
 macro_rules! has_exactly_lines {
-    ($($line:expr),* $(,)?) => {
+    ($($line:expr_2021),* $(,)?) => {
         // Base predicate.
         predicates::str::contains("").normalize()
         // Contains all strings ...
@@ -68,7 +68,7 @@ macro_rules! has_exactly_lines {
         }))
         // ... means it only has these lines.
     };
-    ($($line:expr),* ; $($last_line:expr),* $(,)?) => {
+    ($($line:expr_2021),* ; $($last_line:expr_2021),* $(,)?) => {
         has_exactly_lines!($( $line, )* $( $last_line, )*).and(
             predicates::str::ends_with([$( $last_line, )*].join(""))
         )
@@ -125,13 +125,13 @@ macro_rules! has_exactly_lines {
 /// ```
 #[allow(unused_macros, reason = "used in other test files")]
 macro_rules! has_lines {
-    ($($line:expr),* $(,)?) => {
+    ($($line:expr_2021),* $(,)?) => {
         // Base predicate.
         predicates::str::contains("").normalize()
         // Contains all strings ...
         $( .and(predicates::str::contains($line)) )*
     };
-    ($($line:expr),* ; $($last_line:expr),* $(,)?) => {
+    ($($line:expr_2021),* ; $($last_line:expr_2021),* $(,)?) => {
         has_lines!($( $line, )* $( $last_line, )*).and(
             predicates::str::ends_with([$( $last_line, )*].join(""))
         )


### PR DESCRIPTION
## Summary

Try out Rust edition 2024 on this project following the instructions of <https://blog.rust-lang.org/2024/11/27/Rust-2024-public-testing.html>.