### PR TITLE
Upgrade to the windows-2025 runner for GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
             os: macos-14
             os-name: MacOS
           - target: x86_64-pc-windows-msvc
-            os: windows-2022
+            os: windows-2025
             os-name: Windows
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-24.04

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
           - name: Ubuntu
             os: ubuntu-24.04
           - name: Windows
-            os: windows-2022
+            os: windows-2025
     steps:
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -73,7 +73,7 @@ jobs:
           - name: Ubuntu
             os: ubuntu-24.04
           - name: Windows
-            os: windows-2022
+            os: windows-2025
     steps:
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -281,7 +281,7 @@ jobs:
           - name: Ubuntu
             os: ubuntu-24.04
           - name: Windows
-            os: windows-2022
+            os: windows-2025
     steps:
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -323,7 +323,7 @@ jobs:
           - name: Ubuntu
             os: ubuntu-24.04
           - name: Windows
-            os: windows-2022
+            os: windows-2025
     steps:
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0


### PR DESCRIPTION
Relates to #181, #235

## Summary

~~Try out the `windows-2025` runner for GitHub Actions Following the [announcement on the GitHub Blog](https://github.blog/changelog/2024-12-19-windows-server-2025-is-now-in-public-preview/).~~

Upgrade the windows runners from `windows-2022` to `windows-2025` following <https://github.blog/changelog/2025-04-10-github-actions-macos-15-and-windows-2025-images-are-now-generally-available/>.