### PR TITLE
Set expiry date for the Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,9 @@ The maintainers of the _rust-rm_ project take security issues seriously. We appr
 to responsibly disclose your findings. Due to the non-funded and open-source nature of the project,
 we take a best-efforts approach when it comes to engaging with security reports.
 
+This document should be considered expired after 2025-06-01. If you are reading this after that date
+you should try to find an up-to-date version in the official source repository.
+
 ## Supported Versions
 
 Only the latest release of the project is supported with security updates.


### PR DESCRIPTION
## Summary

Include an expiry date in the security policy primarily as a mechanism to set expectations. Additionally, it should nudge anyone looking at the policy to search for an up-to-date version - which is more helpful for everyone.

The date set here was chosen because it aligns with the expiry date in other projects I maintain.