### PR TITLE
Configure `--in-diff` to optimize mutation testing in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -200,6 +200,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
+          fetch-depth: 0
           persist-credentials: false
       - name: Cache Rust & Cargo
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
@@ -220,6 +221,16 @@ jobs:
         uses: taiki-e/install-action@6aa8b420a527920162babdd71d780f9e5b3b4bc8 # v2.46.1
         with:
           tool: cargo-mutants@24.3.0
+      - name: Determine diff for mutation testing on push
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          git diff 4b825dc642cb6eb9a060e54bf8d69288fbee4904 HEAD >changes.diff
+      - name: Determine diff for mutation testing on Pull Request
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git diff "origin/$BASE" >changes.diff
       - name: Run mutation tests
         run: just ci-mutation
       - name: Upload mutation report

--- a/Justfile
+++ b/Justfile
@@ -129,6 +129,7 @@ alias v := vet
 		--exclude-re 'main -> ExitCode' \
 		--exclude-re rm::dispose \
 		--exclude-re 'impl Display' \
+		{{MUTATION_ARGS}} \
 		-- \
 		{{TEST_UNIT_ARGS}} \
 		{{TEST_FEATURES}}
@@ -314,6 +315,7 @@ STD_TEST_ARGS := ""
 
 CI_ONLY_CARGO_ARGS := if ci == TRUE { "--locked" } else { "" }
 CI_ONLY_COVERAGE_ARGS := if ci == TRUE { "--out lcov" } else { "" }
+CI_ONLY_MUTATION_ARGS := if ci == TRUE { "--in-diff changes.diff" } else { "" }
 CI_ONLY_TEST_ARGS := if ci == TRUE { "--no-fail-fast" } else { "" }
 
 ALL_TEST_FEATURES := "test-dangerous,test-symlink,test-trash"
@@ -321,6 +323,7 @@ ALL_TEST_FEATURES := "test-dangerous,test-symlink,test-trash"
 BUILD_ARGS := STD_BUILD_ARGS + " " + CI_ONLY_CARGO_ARGS
 COVERAGE_ARGS := STD_COVERAGE_ARGS + " " + CI_ONLY_CARGO_ARGS + " " + CI_ONLY_COVERAGE_ARGS
 DOCS_ARGS := STD_DOCS_ARGS + " " + CI_ONLY_CARGO_ARGS
+MUTATION_ARGS := CI_ONLY_MUTATION_ARGS
 TEST_ARGS := STD_TEST_ARGS + " " + CI_ONLY_TEST_ARGS + " " + CI_ONLY_CARGO_ARGS
 TEST_INTEGRATION_ARGS := "--test '*'"
 TEST_UNIT_ARGS := "--bins"


### PR DESCRIPTION
Relates to #51

## Summary

Update how `cargo mutants` is invoked in CI to optimize its use in particular for Pull Requests, only testing what is relevant to the diff.

This implementation maintains a full test run on pushes (to `main`) by diffing against the hash for an empty commit, resulting in a diff that represent the entire code base. The reason for doing a full mutation test run on `main` is to ensure no mutants slip through[^1] when the job duration does not matter.

[^1]: as described in <https://mutants.rs/in-diff.html>.