### PR TITLE
Bump Rust toolchain channel from 1.83 to 1.84

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ To be able to contribute you need the following tooling:
 
 - [git] v2;
 - [Just] v1;
-- [Rust] and [Cargo] v1.83 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
+- [Rust] and [Cargo] v1.84 (edition 2021) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.14.2 or later;
 - (Optional) [cargo-mutants] v23.5.0 or later;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Eric Cornelissen <ericornelissen@gmail.com>"]
 repository = "https://github.com/ericcornelissen/rust-rm"
 keywords = ["cli", "rm", "trash"]
 categories = ["development-tools", "filesystem"]
-rust-version = "1.83"
+rust-version = "1.84"
 edition = "2021"
 
 [features]
@@ -42,7 +42,7 @@ proptest-attr-macro = "1.0.0"
 proptest-derive = "0.5.0"
 
 [lints.rust]
-unexpected_cfgs = { level = "deny", check-cfg = ['cfg(tarpaulin_include)'] }
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(feature, values("test"))', 'cfg(tarpaulin_include)'] }
 
 [profile.release]
 debug = false

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT-0
 
-FROM docker.io/rust:1.83.0-alpine3.20
+FROM docker.io/rust:1.84.0-alpine3.20
 
 RUN apk add --no-cache \
 	bash git just libressl-dev musl-dev perl \

--- a/Justfile
+++ b/Justfile
@@ -232,9 +232,12 @@ _profile_prepare:
 		--deny clippy::iter_over_hash_type \
 		--deny clippy::impl_trait_in_params \
 		--deny clippy::indexing_slicing \
+		--deny clippy::map_with_unused_argument_over_ranges \
 		--deny clippy::missing_asserts_for_indexing \
 		--deny clippy::missing_docs_in_private_items \
 		--deny clippy::missing_enforced_import_renames \
+		--deny clippy::module_name_repetitions \
+		--deny clippy::non_zero_suggestions \
 		--deny clippy::pathbuf_init_then_push \
 		--deny clippy::print_stderr \
 		--deny clippy::print_stdout \

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ rm -fq file1 file2
 
 ## Build from Source
 
-To build from source you need [Rust] and [Cargo], v1.83 or higher, installed on your system. Then
+To build from source you need [Rust] and [Cargo], v1.84 or higher, installed on your system. Then
 run the command:
 
 ```shell

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Check out rustup at: https://rust-lang.github.io/rustup/index.html
 
 [toolchain]
-channel = "1.83.0"
+channel = "1.84.0"
 components = [
     "cargo",
     "clippy",


### PR DESCRIPTION
Relates to #292

## Summary

Upgrade the version of Rust and related tooling from 1.83.0 to 1.84.0, which was recently released (see <https://blog.rust-lang.org/2025/01/09/Rust-1.84.0.html>).