### PR TITLE
Update tooling to latest version

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -46,6 +46,6 @@ jobs:
       - name: Install cargo-deny
         uses: taiki-e/install-action@7ea888af71a31437ad4e71c62d021b3bb2728ea9 # v2.49.3
         with:
-          tool: cargo-deny@0.14.11
+          tool: cargo-deny@0.18.0
       - name: Audit
         run: just ci-audit

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -43,6 +43,6 @@ jobs:
       - name: Install cargo-deny
         uses: taiki-e/install-action@7ea888af71a31437ad4e71c62d021b3bb2728ea9 # v2.49.3
         with:
-          tool: cargo-deny@0.14.11
+          tool: cargo-deny@0.18.0
       - name: Check compliance
         run: just ci-compliance

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Install cargo-tarpaulin
         uses: taiki-e/install-action@7ea888af71a31437ad4e71c62d021b3bb2728ea9 # v2.49.3
         with:
-          tool: cargo-tarpaulin@0.31.2
+          tool: cargo-tarpaulin@0.32.0
       - name: Run all tests with coverage
         run: just ci-coverage
       - name: Upload coverage report
@@ -220,7 +220,7 @@ jobs:
       - name: Install cargo-mutants
         uses: taiki-e/install-action@7ea888af71a31437ad4e71c62d021b3bb2728ea9 # v2.49.3
         with:
-          tool: cargo-mutants@24.3.0
+          tool: cargo-mutants@25.0.0
       - name: Determine diff for mutation testing on push
         if: ${{ github.event_name != 'pull_request' }}
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,8 +112,8 @@ To be able to contribute you need the following tooling:
 - [Just] v1;
 - [Rust] and [Cargo] v1.85 (edition 2024) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
-- (Optional) [cargo-deny] v0.14.2 or later;
-- (Optional) [cargo-mutants] v23.5.0 or later;
+- (Optional) [cargo-deny] v0.18.0 or later;
+- (Optional) [cargo-mutants] v25.0.0 or later;
 - (Optional) [cargo-tarpaulin] v0.31.2 or later;
 - (Suggested) a code editor with [EditorConfig] support;
 

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -9,9 +9,9 @@ RUN apk add --no-cache \
 
 RUN cargo install \
 	cargo-all-features@1.10.0 \
-	cargo-deny@0.14.11 \
-	cargo-mutants@24.3.0 \
-	cargo-tarpaulin@0.31.2
+	cargo-deny@0.18.0 \
+	cargo-mutants@25.0.0 \
+	cargo-tarpaulin@0.32.0
 
 WORKDIR /rust-rm
 COPY ./ ./

--- a/deny.toml
+++ b/deny.toml
@@ -2,8 +2,6 @@
 
 [advisories]
 ignore = []
-unmaintained = "warn"
-vulnerability = "deny"
 yanked = "deny"
 
 [licenses]
@@ -14,7 +12,4 @@ allow = [
     "Unicode-DFS-2016",
 ]
 confidence-threshold = 0.8
-deny = []
-default = "deny"
 include-dev = true
-unlicensed = "deny"


### PR DESCRIPTION
Relates to #191, #223, #287

## Summary

- Update `cargo-deny` from 0.14.11 to 0.18.0 and bump the minimum version to this version. This is because somewhere along this line of upgrades there were backwards incompatible changes to the config file format (adjusted for here too, with no intent to change the policy), so we'll just adopt the latest as minimum.
- Update `cargo-mutants` from 24.3.0 to 25.0.0 and set it as the minimum as well. While the previous minimum is still functional, there's a discrepancy in the number of mutants covered. Hence, for consistency, we adopt this new version as the minimum too.
- Update `cargo-tarpaulin` from 0.31.2 to 0.32.0. The old minimum version still works so it's not updated.