### PR TITLE
Bump Rust toolchain channel from 1.85 to 1.86

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ To be able to contribute you need the following tooling:
 
 - [git] v2;
 - [Just] v1;
-- [Rust] and [Cargo] v1.85 (edition 2024) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
+- [Rust] and [Cargo] v1.86 (edition 2024) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.18.0 or later;
 - (Optional) [cargo-mutants] v25.0.0 or later;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Eric Cornelissen <ericornelissen@gmail.com>"]
 repository = "https://github.com/ericcornelissen/rust-rm"
 keywords = ["cli", "rm", "trash"]
 categories = ["development-tools", "filesystem"]
-rust-version = "1.85"
+rust-version = "1.86"
 edition = "2024"
 
 [features]

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT-0
 
-FROM docker.io/rust:1.85.0-alpine3.21
+FROM docker.io/rust:1.86.0-alpine3.21
 
 RUN apk add --no-cache \
 	bash git just libressl-dev musl-dev perl \

--- a/Justfile
+++ b/Justfile
@@ -242,12 +242,14 @@ _profile_prepare:
 		--deny clippy::module_name_repetitions \
 		--deny clippy::non_zero_suggestions \
 		--deny clippy::pathbuf_init_then_push \
+		--deny clippy::precedence_bits \
 		--deny clippy::print_stderr \
 		--deny clippy::print_stdout \
 		--deny clippy::rc_buffer \
 		--deny clippy::rc_mutex \
 		--deny clippy::ref_patterns \
 		--deny clippy::renamed_function_params \
+		--deny clippy::return_and_then \
 		--deny clippy::string_lit_chars_any \
 		--deny clippy::unused_result_ok \
 		--deny clippy::unused_trait_names \

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ rm -fq file1 file2
 
 ## Build from Source
 
-To build from source you need [Rust] and [Cargo], v1.85 or higher, installed on your system. Then
+To build from source you need [Rust] and [Cargo], v1.86 or higher, installed on your system. Then
 run the command:
 
 ```shell

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Check out rustup at: https://rust-lang.github.io/rustup/index.html
 
 [toolchain]
-channel = "1.85.0"
+channel = "1.86.0"
 components = [
     "cargo",
     "clippy",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2247,11 +2247,11 @@ mod walk {
 
                 assert!(
                     out.iter()
-                        .filter_map(|x| if let Ok(x) = x { Some(x) } else { None })
+                        .filter_map(|x| x.clone().ok())
                         .position(|x| x.path() == nested_file_path)
                         < out
                             .iter()
-                            .filter_map(|x| if let Ok(x) = x { Some(x) } else { None })
+                            .filter_map(|x| x.clone().ok())
                             .position(|x| x.path() == nested_dir_path)
                 );
                 assert_eq!(out.last(), Some(&fs::open(dir_path)));


### PR DESCRIPTION
Relates to #320

## Summary

Upgrade the version of Rust and related tooling from 1.85.0 to [1.86.0, which was recently released](https://blog.rust-lang.org/2025/04/03/Rust-1.86.0.html). For Clippy, two new optional rules from the "restriction" group has been enabled. The refactoring in `main.rs` is due to Clippy's new `manual_ok_err` rule.