### PR TITLE
Bump `runs-on:` values

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,13 +18,13 @@ jobs:
       matrix:
         include:
           - target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-15
             os-name: MacOS
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04
             os-name: Ubuntu
           - target: x86_64-apple-darwin
-            os: macos-14
+            os: macos-15
             os-name: MacOS
           - target: x86_64-pc-windows-msvc
             os: windows-2022

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-14
+            os: macos-15
           - name: Ubuntu
             os: ubuntu-24.04
           - name: Windows
@@ -69,7 +69,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-14
+            os: macos-15
           - name: Ubuntu
             os: ubuntu-24.04
           - name: Windows
@@ -277,7 +277,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-14
+            os: macos-15
           - name: Ubuntu
             os: ubuntu-24.04
           - name: Windows
@@ -319,7 +319,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-14
+            os: macos-15
           - name: Ubuntu
             os: ubuntu-24.04
           - name: Windows


### PR DESCRIPTION
Relates to #181

## Summary

Following <https://github.blog/changelog/2025-04-10-github-actions-macos-15-and-windows-2025-images-are-now-generally-available/>.