### PR TITLE
Bump Rust toolchain channel from 1.87 to 1.88

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ To be able to contribute you need the following tooling:
 
 - [git] v2;
 - [Just] v1;
-- [Rust] and [Cargo] v1.87 (edition 2024) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
+- [Rust] and [Cargo] v1.88 (edition 2024) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.18.0 or later;
 - (Optional) [cargo-mutants] v25.0.0 or later;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Eric Cornelissen <ericornelissen@gmail.com>"]
 repository = "https://github.com/ericcornelissen/rust-rm"
 keywords = ["cli", "rm", "trash"]
 categories = ["development-tools", "filesystem"]
-rust-version = "1.87"
+rust-version = "1.88"
 edition = "2024"
 
 [features]

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT-0
 
-FROM docker.io/rust:1.87.0-alpine3.21
+FROM docker.io/rust:1.88.0-alpine3.21
 
 RUN apk add --no-cache \
 	bash git just libressl-dev musl-dev perl \

--- a/Justfile
+++ b/Justfile
@@ -247,6 +247,7 @@ _profile_prepare:
 		--deny clippy::print_stdout \
 		--deny clippy::rc_buffer \
 		--deny clippy::rc_mutex \
+		--deny clippy::redundant_test_prefix \
 		--deny clippy::ref_patterns \
 		--deny clippy::renamed_function_params \
 		--deny clippy::return_and_then \

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ rm -fq file1 file2
 
 ## Build from Source
 
-To build from source you need [Rust] and [Cargo], v1.87 or higher, installed on your system. Then
+To build from source you need [Rust] and [Cargo], v1.88 or higher, installed on your system. Then
 run the command:
 
 ```shell

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Check out rustup at: https://rust-lang.github.io/rustup/index.html
 
 [toolchain]
-channel = "1.87.0"
+channel = "1.88.0"
 components = [
     "cargo",
     "clippy",


### PR DESCRIPTION
Relates to #343

## Summary

Upgrade the version of Rust and related tooling from 1.87.0 to 1.88.0, which was recently released <https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/>.