### PR TITLE
Enable CodeQL analysis of Rust code

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - .github/workflows/*
       - .github/codeql.yml
+      - src/*.rs
   push:
     branches:
       - main
@@ -12,8 +13,14 @@ permissions: read-all
 
 jobs:
   codeql:
-    name: actions
+    name: ${{ matrix.language }}
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - rust
     permissions:
       security-events: write # To upload CodeQL results
     steps:
@@ -22,9 +29,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
+        uses: github/codeql-action/init@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
           config-file: ./.github/codeql.yml
-          languages: actions
+          languages: ${{ matrix.language }}
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
+        uses: github/codeql-action/analyze@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2


### PR DESCRIPTION
Relates to #313, #355, #356

## Summary

Enables CodeQL analysis of Rust code for this project.

See also

- <https://github.blog/changelog/2025-06-30-codeql-support-for-rust-now-in-public-preview/>
- <https://github.blog/changelog/2025-07-02-codeql-2-22-1-bring-rust-support-to-public-preview/>