### PR TITLE
Enable Dependabot updates for the Rust toolchain version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,11 @@ updates:
     labels:
       - ci/cd
       - dependencies
+  - package-ecosystem: rust-toolchain
+    directory: /
+    open-pull-requests-limit: 1
+    schedule:
+      interval: daily
+      time: "04:00"
+    labels:
+      - dependencies


### PR DESCRIPTION
Following the [Dependabot now supports Rust toolchain updates](https://github.blog/changelog/2025-08-19-dependabot-now-supports-rust-toolchain-updates/) announcement.