### PR TITLE
Bump Rust toolchain channel from 1.89 to 1.90

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ To be able to contribute you need the following tooling:
 
 - [git] v2;
 - [Just] v1;
-- [Rust] and [Cargo] v1.89 (edition 2024) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
+- [Rust] and [Cargo] v1.90 (edition 2024) with [Clippy], [rustfmt] (see `rust-toolchain.toml`);
 - (Optional) [cargo-all-features] v1.7.0 or later;
 - (Optional) [cargo-deny] v0.18.0 or later;
 - (Optional) [cargo-mutants] v25.0.0 or later;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Eric Cornelissen <ericornelissen@gmail.com>"]
 repository = "https://github.com/ericcornelissen/rust-rm"
 keywords = ["cli", "rm", "trash"]
 categories = ["development-tools", "filesystem"]
-rust-version = "1.89"
+rust-version = "1.90"
 edition = "2024"
 
 [features]

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT-0
 
-FROM docker.io/rust:1.89.0-alpine3.21
+FROM docker.io/rust:1.90.0-alpine3.22
 
 RUN apk add --no-cache \
 	bash git just libressl-dev musl-dev perl \

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ rm -fq file1 file2
 
 ## Build from Source
 
-To build from source you need [Rust] and [Cargo], v1.89 or higher, installed on your system. Then
+To build from source you need [Rust] and [Cargo], v1.90 or higher, installed on your system. Then
 run the command:
 
 ```shell

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Check out rustup at: https://rust-lang.github.io/rustup/index.html
 
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"
 components = [
     "cargo",
     "clippy",


### PR DESCRIPTION
Relates to #366

## Summary

Upgrade the version of Rust and related tooling from 1.88.0 to 1.89.0, which was [recently released](https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/). There are no new Clippy rules to be enabled in this version.